### PR TITLE
Distinct Value Query for public HTTP API Docs

### DIFF
--- a/docs/concepts/http.md
+++ b/docs/concepts/http.md
@@ -262,7 +262,7 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   Content-Type: application/json
   X-HYDRA-VERSION: 7
 
-  {"start": null, "end": null,"paths":[["deviceId"]],"timeout_millis":null}
+  {"start": null, "end": null,"paths":[["parent", "child", "grandchild"]],"timeout_millis":null}
   ```
 
   Response
@@ -271,7 +271,7 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   HTTP/1.1 200 OK
   Content-Type: application/json-l
   X-HYDRA-VERSION: 7
-  {"item":{"[\"minutes\"]":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]}}
+  {"item":{"[\"parent\", \"child\", \"grandchild\"]":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]}}
 
   ```
   Note also the X-HYDRA-VERSION value is included the Response Header


### PR DESCRIPTION
As requested by particle, the HTTP API docs updated with how to do a distinct value query.