### PR TITLE
Fix bugs in webhook permissions specs and JS client auth

### DIFF
--- a/docs/concepts/security/online-with-authentication/setup-authentication-webhook.mdx
+++ b/docs/concepts/security/online-with-authentication/setup-authentication-webhook.mdx
@@ -127,6 +127,11 @@ To grant full `read` permissions to _all collections_ and _all documents_:
     // highlight-start
     "read": {
       "everything": true,
+      "queriesByCollection": {}
+    },
+    "write": {
+      "everything": false,
+      "queriesByCollection": {}
     }
     // highlight-end
   }
@@ -141,8 +146,13 @@ To grant full `write` permissions to _all collections_ and _all documents_:
   "expirationSeconds": 28800,
   "userID": "123abc",
   "permissions": {
+    "read": {
+      "everything": false,
+      "queriesByCollection": {}
+    },
     "write": {
       "everything": true,
+      "queriesByCollection": {}
     }
   }
 }
@@ -156,11 +166,13 @@ To grant full `read` & `write` permissions to _all collections_ and _all documen
   "expirationSeconds": 28800,
   "userID": "123abc",
   "permissions": {
-    "write": {
-      "everything": true,
-    },
     "read": {
       "everything": true,
+      "queriesByCollection": {}
+    },
+    "write": {
+      "everything": true,
+      "queriesByCollection": {}
     }
   }
 }
@@ -168,7 +180,7 @@ To grant full `read` & `write` permissions to _all collections_ and _all documen
 
 ##### Granting selective permissions on certain documents
 
-To grant selective permissions on specific documents, add `queriesByCollection` property inside either the `read` or `write` property. Each key inside `queriesByCollection` is a reference to the collection. Each value is an array of [ditto queries](/concepts/querying) describing which documents the user can read or write.
+To grant selective permissions on specific documents, add to the `queriesByCollection` property inside either the `read` or `write` property. Each key inside `queriesByCollection` is a reference to the collection. Each value is an array of [ditto queries](/concepts/querying) describing which documents the user can read or write.
 
 :::info
 Currently, you can __only specify a permission query on the `_id` field of a document__. Mutable properties are currently not supported. We are working on adding this feature.
@@ -206,12 +218,14 @@ The following write permissions below describe that `userID: "123abc"` can
     },
     "read": {
       "everything": false, // ensure that this is false
-      // highlight-start
-      // 3. 
-      "books": [
-        "endsWith(_id.title, 'Potter')"
-      ],
-      // highlight-end
+      "queriesByCollection": {
+        // highlight-start
+        // 3.
+        "books": [
+          "endsWith(_id.title, 'Potter')"
+        ],
+        // highlight-end
+      }
     }
   }
 }

--- a/docs/concepts/security/online-with-authentication/setup-client-side.mdx
+++ b/docs/concepts/security/online-with-authentication/setup-client-side.mdx
@@ -29,10 +29,9 @@ import { init, Ditto } from "@dittolive/ditto"
   await init() // you need to call this at least once before using any of the Ditto API
 
   const authHandler = {
-    authenticationRequired: function(authenticator) {
-      authenticator.loginWithToken(ThirdPartyAuth.getToken(), "third_party", (err) => {
-        console.log(`Login request completed. Error? ${err}`)
-      })
+    authenticationRequired: async function(authenticator) {
+      await authenticator.loginWithToken(ThirdPartyAuth.getToken(), "third_party");
+      console.log("Login request completed.");
     },
     authenticationExpiringSoon: function(authenticator, secondsRemaining) {
       console.log(`Auth token expiring in ${secondsRemaining} seconds`)


### PR DESCRIPTION
* The webhook response must include both `read` and `write` sections, and those must include `queriesByCollection` properties.
* `loginWithToken()` takes two parameters and must be awaited. Error conditions are signalled by rejection of the Promise.