### PR TITLE
Replaces the GA4 measurement ID with GTM.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,14 @@ module.exports = {
   favicon: "img/favicon.ico/favicon.ico",
   organizationName: "getditto", // Usually your GitHub org/user name.
   projectName: "docs", // Usually your repo name.
-  plugins: [path.resolve(__dirname, "plugins/postcss-tailwindcss-loader")],
+  plugins: [path.resolve(__dirname, "plugins/postcss-tailwindcss-loader"),
+    [
+      require.resolve('docusaurus-gtm-plugin'),
+      {
+        id: 'GTM-PV7QFWF',
+      }
+    ]
+  ],
   themeConfig: {
     colorMode: {
       defaultMode: 'light',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "axios": "^0.21.4",
     "clsx": "^1.1.1",
     "common-tags": "^1.8.0",
+    "docusaurus-gtm-plugin": "^0.0.2",
     "file-loader": "^6.2.0",
     "lottie-web": "^5.7.13",
     "markdown-it": "^12.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4940,6 +4940,11 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
+docusaurus-gtm-plugin@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-gtm-plugin/-/docusaurus-gtm-plugin-0.0.2.tgz#f39864b54ca594e3281902c23b6df0763761602b"
+  integrity sha512-Xx/df0Ppd5SultlzUj9qlQk2lX9mNVfTb41juyBUPZ1Nc/5dNx+uN0VuLyF4JEObkDRrUY1EFo9fEUDo8I6QOQ==
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"


### PR DESCRIPTION
We need to get cross domain tracking to work on the website, docs and the portal. To do so we need to create each of these sites as data streams on the GA4 panel, and have all of them using Google Tag Manger.