### PR TITLE
Update permissions/manifests to account for Bluetooth on Android 12

### DIFF
--- a/docs/advanced/platform-permissions/android-platform-permissions.mdx
+++ b/docs/advanced/platform-permissions/android-platform-permissions.mdx
@@ -5,9 +5,40 @@ sidebar_position: 2
 
 # Android Platform Permissions
 
-The Android operating system restricts access to some of this functionality for the sake of user control and privacy. Therefore, to unlock the full capabilities of Ditto, it is essential to configure your app so that it requests all the permissions that it needs.
+The Android operating system restricts access to some functionality for the sake of user control and privacy. Therefore, to unlock the full capabilities of Ditto, it is essential to configure your app so that it requests all the permissions that it needs.
 
-First, add the following permissions in your app's Manifest.xml file:
+First you must the following permissions in your app's `AndroidManifest.xml` file.
+
+Then at runtime your app must prompt the user to request certain permissions.
+
+## Modern Manifest (API Level > 30)
+
+```xml title=AndroidManifest.xml
+<uses-permission android:name="android.permission.BLUETOOTH"
+    android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+    android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+    android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+```
+
+Since the Ditto SDK does not use BLE to locate the user physically it assumes you are using the `neverForLocation` flag on `BLUETOOTH_SCAN`. On Android 12, this means that `ACCESS_FINE_LOCATION` is no longer required. If you wish to use `ACCESS_FINE_LOCATION` on an app targeting API level 31+, you must check for and request this permission on your own. Refer to the [Android Documentation](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions) for details.
+
+## Legacy Manifest (API Level <= 30)
+
+The following manifest is sufficient for apps that are not yet targeting Android 12.
 
 ```xml title=AndroidManifest.xml
 <uses-permission android:name="android.permission.BLUETOOTH" />
@@ -22,23 +53,26 @@ First, add the following permissions in your app's Manifest.xml file:
 <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 ```
 
-You may notice `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION`. This is because ditto does not use the GPS information from the phone, however these two permissions are required to enable Bluetooth Low Energy communication to work correctly.
+In these older Android versions, `ACCESS_FINE_LOCATION` is mandatory and Ditto will check that it is present.
 
+## Runtime Permissions
 
-You may need to check if the device allows for the necessary location permissions. The following code is from the example Task app. For more information about requesting permissions in a user-friendly way refer to Android's documentation: [Request App Permissions](https://developer.android.com/training/permissions/requesting).
+Your apps must ensure all required permissions for sync have been requested from the user. The Android Ditto SDK provides a `DittoSyncPermissions` helper which makes this easy. For example, a fragment can use a method like this:
 
 ```kotlin
-fun checkLocationPermission() {
-    // On Android, parts of Bluetooth LE and WiFi Direct require location permission
-    // Ditto will operate without it but data sync may be impossible in certain scenarios
-    if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
-            != PackageManager.PERMISSION_GRANTED) {
-        // For this app we will prompt the user for this permission every time if it is missing
-        // We ignore the result - Ditto will automatically notice when the permission is granted
-        ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), 0);
+fun checkPermissions() {
+    val missing = DittoSyncPermissions(requireActivity()).missingPermissions()
+    if (missing.isNotEmpty()) {
+        ActivityCompat.requestPermissions(
+            requireActivity(),
+            missing,
+            0
+        )
     }
 }
 ```
+
+For more information about requesting permissions in a user-friendly way refer to Android's documentation: [Request App Permissions](https://developer.android.com/training/permissions/requesting).
 
 On Android there may be a noticeable delay between when the user grants location access and when Ditto notices the new permission. For this reason it is recommended to call `refreshPermissions()` whenever a relevant permission might have changed. This will force an immediate check. If a permission has become available your app can begin syncing as quickly as possible.
 

--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -24,19 +24,27 @@ buildscript {
 
 <InstallCode framework="android" />
 
-4. Configure your manifest with the following permissions:
+4. Configure your manifest with the following permissions. Ditto's required permissions have changed since Android 12. Refer to [Android Platform Permissions](/advanced/platform-permissions/android-platform-permissions) for details.
 
 ```xml
-<uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 ```
 
 5. Register your license token as below. We recommend placing this in your Application.onCreate method:

--- a/docs/tutorials/tasks/android-kotlin/1-setup.md
+++ b/docs/tutorials/tasks/android-kotlin/1-setup.md
@@ -22,16 +22,24 @@ In newer version of Android Studio the Basic Activity template includes addition
 Android requires requesting permission to use Bluetooth Low Energy and P2P Wifi, open the `AndroidManifest.xml` and add the following:
 
 ```xml title=AndroidManifest.xml
-<uses-permission android:name="android.permission.BLUETOOTH" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-<uses-permission android:name="android.permission.INTERNET" />
-<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-<uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
-<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 ```
 
 It should look like this now:

--- a/docs/tutorials/tasks/jetpack-compose/2-configure-ditto.md
+++ b/docs/tutorials/tasks/jetpack-compose/2-configure-ditto.md
@@ -50,16 +50,24 @@ In order for Ditto to sync, we will need to add permissions to the __AndroidMani
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="live.ditto.compose.tasks">
 
-+    <uses-permission android:name="android.permission.BLUETOOTH" />
-+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
++    <uses-permission android:name="android.permission.BLUETOOTH"
++        android:maxSdkVersion="30" />
++    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
++        android:maxSdkVersion="30" />
++    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
++        android:usesPermissionFlags="neverForLocation" />
++    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
++    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
++    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
++        android:maxSdkVersion="30" />
 +    <uses-permission android:name="android.permission.INTERNET" />
 +    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 +    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 +    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
++    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
++    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
 
     <application


### PR DESCRIPTION
Should not be merged until the next release as the referenced DittoSyncPermissions class is not yet available.