### PR TITLE
Improve HTTP Documentation

### DIFF
--- a/docs/concepts/data-model.mdx
+++ b/docs/concepts/data-model.mdx
@@ -230,7 +230,6 @@ let _doc_id = ditto.store().collection("people")?.insert(person, Some(&doc_id), 
 
 ```bash
 curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/123abc' \
-    --header 'Accept: application/json' \
     --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
     --header 'Content-Type: application/json' \
     --data-raw '{"name": "Susan", "age": 31}'
@@ -358,7 +357,6 @@ let doc_id = ditto.store().collection("people")?.insert(person, None, is_default
 
 ```bash
 curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents' \
-  --header 'Accept: application/json' \
   --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
   --header 'Content-Type: application/json' \
   --data-raw '{"name": "Susan", "age": 31}'
@@ -512,7 +510,6 @@ DocumentId doc_id = ditto.store
 
   ```bash
   curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents' \
-      --header 'Accept: application/json' \
       --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
       --header 'Content-Type: application/json' \
       --data-raw "{"_id": {"user_id": "456abc", "work_id": 789}, "name": "Susan", "age": 31}"
@@ -780,7 +777,6 @@ ditto.store.collection("foo").insert({
 
 ```bash
 curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/123abc' \
-    --header 'Accept: application/json' \
     --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
     --header 'Content-Type: application/json' \
     --data-raw '{ "boolean": true, "string": "Hello World", "number": 10, "map": { "key": "value"}, "array": [1, 2, 3], "null": null }'

--- a/docs/concepts/data-model.mdx
+++ b/docs/concepts/data-model.mdx
@@ -26,7 +26,7 @@ To get a reference to a collection:
     {label: 'Java', value: 'java'},
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
+    {label: 'Rust', value: 'rust'}
   ]
 }>
 <TabItem value="javascript">
@@ -91,6 +91,7 @@ let cars_collection = store.collection("cars")?;
 ```
 
 </TabItem>
+
 </Tabs>
 
 ## Documents
@@ -113,6 +114,7 @@ You can supply your own unique identifier when creating a document:
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -219,6 +221,18 @@ let _doc_id = ditto.store().collection("people")?.insert(person, Some(&doc_id), 
 ```
 
 </TabItem>
+
+<TabItem value="http">
+
+```bash
+curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/123abc' \
+    --header 'Accept: application/json' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "Susan", "age": 31}'
+```
+
+</TabItem>
 </Tabs>
 
 The id parameter is optional during insertion. If you do not supply a document `_id`, Ditto will automatically generate a random, unique string and use that as the document's `_id` instead.
@@ -235,6 +249,7 @@ The id parameter is optional during insertion. If you do not supply a document `
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -334,6 +349,19 @@ let doc_id = ditto.store().collection("people")?.insert(person, None, is_default
 ```
 
 </TabItem>
+
+<TabItem value="http">
+
+```bash
+curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents' \
+  --header 'Accept: application/json' \
+  --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{"name": "Susan", "age": 31}'
+```
+
+</TabItem>
+
 </Tabs>
 
 ### Composite Primary Keys
@@ -353,6 +381,7 @@ You may have a data model where documents are considered unique due to two or mo
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -475,6 +504,17 @@ DocumentId doc_id = ditto.store
   ```
 
 </TabItem>
+<TabItem value="http">
+
+  ```bash
+  curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents' \
+      --header 'Accept: application/json' \
+      --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+      --header 'Content-Type: application/json' \
+      --data-raw "{"_id": {"user_id": "456abc", "work_id": 789}, "name": "Susan", "age": 31}"
+  ```
+
+</TabItem>
 </Tabs>
 
 
@@ -531,9 +571,11 @@ Document values support all JSON compatible values like `string`, `boolean`, `nu
     </tr>
     <tr>
       <td>
-        <p><code>null</code></p>
+        <code>null</code>
       </td>
-      <td>This represents an absence of value</td>
+      <td>
+        This represents an absence of value
+      </td>
     </tr>
     <tr>
       <td>
@@ -590,6 +632,7 @@ The following snippets show a various set of data types
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -729,6 +772,17 @@ ditto.store.collection("foo").insert({
 
 </TabItem>
 
+<TabItem value="http">
+
+```bash
+curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/123abc' \
+    --header 'Accept: application/json' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{ "boolean": true, "string": "Hello World", "number": 10, "map": { "key": "value"}, "array": [1, 2, 3], "null": null }'
+```
+</TabItem>
+
 </Tabs>
 
 ## Binary Data - Attachments
@@ -749,6 +803,7 @@ Attachments do not get synced between devices by default, even if they are part 
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -1017,6 +1072,9 @@ std::unique_ptr<AttachmentFetcher> fetcher = collection.fetch_attachment(
   std::fs::read(attachment_file_path)?;
   ```
 
+</TabItem>
+<TabItem value="http">
+  Attachments are not supported by the HTTP API.
 </TabItem>
 </Tabs>
 

--- a/docs/concepts/data-model.mdx
+++ b/docs/concepts/data-model.mdx
@@ -26,7 +26,8 @@ To get a reference to a collection:
     {label: 'Java', value: 'java'},
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'}
+    {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -90,6 +91,9 @@ let store = ditto.store();
 let cars_collection = store.collection("cars")?;
 ```
 
+</TabItem>
+<TabItem value="http">
+An HTTP client creates a new collection by adding a new document (see below).
 </TabItem>
 
 </Tabs>
@@ -1101,6 +1105,7 @@ Once the value in the document is a counter, you can proceed to increment or dec
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -1239,4 +1244,10 @@ ditto.store
   ```
 
 </TabItem>
+<TabItem value="http">
+
+Counters are not supported by the HTTP API.
+
+</TabItem>
+
 </Tabs>

--- a/docs/concepts/http.md
+++ b/docs/concepts/http.md
@@ -1,15 +1,25 @@
----
-title: Ditto Cloud HTTP Interface
-sidebar_position: 7
----
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+# Ditto HTTP API Reference
 
-The Ditto HTTP API provides a programmatic interface for interactions with Ditto Cloud. The canonical root URL for the HTTP API is `https://<app-uuid>.cloud.ditto.live/api/v1/`, for example `https://f81d4fae-7dec-11d0-a765-00a0c91e6bf6.cloud.ditto.live/api/v1/`
+<!-- This document is intended to serve as a public facing guide to the entire HTTP API at the time we deliver Particle phase 1. Items for future work or discussion will be called out in comments like this. -->
+
+The Ditto HTTP API provides a programmatic interface for interactions with Ditto-powered Apps which expose an HTTP Server Interface. A primary use case for the HTTP API is external systems which integrate with `cloud.ditto.live`.
+
+## Root URL
+
+The canonical root URL for the HTTP API is `https://<app-uuid>.cloud.ditto.live/api/v1/`.
+The standard port 443 is used.
+
+API Clients may also use the more convenient `https://<app-slug>.<org-slug>.cloud.ditto.live/api/v1/` in future releases.
+
+_Example_
+
+```bash
+curl https://f81d4fae-7dec-11d0-a765-00a0c91e6bf6.cloud.ditto.live/api/v1/
+```
 
 ## Authorization
 
-Access to the Ditto HTTP API is mediated by an `Authorization: Bearer` HTTP Header containing a valid, signed, JWT Token (RFC 7519). This token can be obtained from the appropriate login endpoint.
+Access to the Ditto HTTP API is mediated by an `Authorization: Bearer` HTTP Header containing a valid, signed, JWT Token (RFC 7519). This token can be obtained from the appropriate `login` endpoint.
 
 The JWT encodes the identity of the client, the target application, and the permissions the client is entitled to access.
 
@@ -19,36 +29,71 @@ Ditto uses transactions to group related operations together. Typically, each HT
 
 In each API Request a `Transaction ID` may optionally be provided in an HTTP HEADER called `X-HYDRA-VERSION` with an integer value, which represents this request should be applied to the "version" of the data _at least_ as recent as this value. Using the example above, if we inserted some events in Transaction 17, and we wanted to ensure they were included in our subsequent query, we would include the header `X-HYDRA-VERSION: 17` in our request. If we don't supply this header, the default behavior is to use the most recent version common to all Ditto nodes. Note also that if the Ditto node servicing the Request can't supply the version of the data requested, an error will be returned.
 
-In the example above, we mentioned that the insertion occurred in Transaction 17, but how does the client know this? When POSTing data to Ditto, the client should include an HTTP HEADER `X-HYDRA-CLIENT-ID: base64Encode(<unsigned 128 bit integer>)`.  This client ID is used as an unique identifier that represents a unique install of Ditto and the state of its memory.  To quickly get started with the API it is okay to base64Encode a random 128-bit integer and use that for all the HTTP requests for one client.
+<!-- Current implementation requires an Actor ID however in the future only the Site ID will be needed. -->
 
-Potential Pitfall:  This ID represents a client in the Ditto mesh.  Generating a new ID for each request, rather than one for the HTTP client, could cause performance issues.  When possible generate this ID and cache it for the duration of the client.
+In the example above, we mentioned that the insertion occurred in Transaction 17, but how does the client know this? When POSTing data to Ditto, the client should include an HTTP HEADER `X-HYDRA-CLIENT-ID: base64Encode(<u128 Actor ID>)`, that is a `Actor ID` which can be parsed as an u128 and which has been base64 encoded. The Actor ID represents which peer in the Ditto mesh is writing to Ditto. You can [generate an Actor ID](#generating-an-actor-id) by concatenating the Big Endian bytes for a Site ID and the current Epoch. You should typically use the same Site ID scheme as your other SDK-based Ditto Apps and only change your Site ID when you want to indicate a new client is inserting or deleting data. If successful, the response to POST or DELETE requests will include a Transaction ID, which can be used on subsequent GET requests. This type of insertion is non-blocking and so is very performant.
 
 Ditto uses "delete-wins" semantics, so in some situations the client may want to force Ditto to first read its current data and ensure another peer hasn't issued a concurrent DELETE request before attempting an insertion with a POST request. To do this, the client provides the HTTP HEADER `X-HYDRA-ENSURE-INSERT: true`.
 
+<!-- Note that PATCH and PUT update operations are not yet implemented but likely will have similar rules -->
+
 ## HTTP Methods
 
-Ditto's HTTP API uses HTTP Methods (aka "verbs") to distinguish between typical insertion, deletion, update, fetch, and query operations. The mapping is based on common convention seen in RESTful HTTP APIs.
+Ditto's HTTP API uses HTTP Methods (aka "verbs") to distinguish between typical insertion, deletion, update, fetch, and query operations. The mapping is based on common convention seen in RESTful HTTP APIs. The meaning of various HTTP methods by be slightly changed depending on the value of headers like `Content-Type` and if the requested resource is a single document or multiple documents.
 
 - GET - Used to get the version of an individual resource and to query a collection of resources.
 - POST - Used to create one or more Documents in a Collection or Events in a TimeSeries. Requests that would insert a duplicate copy of a resource may result in a client error. The specific behavior for individual resources is described below.
 - DELETE - Used to remove a resource. As discussed above other clients may try to concurrently insert or modify this resource, but DELETE requests take precedence.
+<!-- Note that PUT and PATCH are not currently implemented -->
+- PUT - _Reserved for future use_
+- PATCH - _Reserved for future use_
+
+<!-- The SubServer acts like an HTTP proxy but I don't think the current design can support HTTP/2 at all -->
 
 ## Common Query Parameters
 
-- find - A query used to filter the target collection or time series
+- find - A JMESPath formatted string used to filter the target collection or time series
 - limit - Used to limit the number of resources returned in a query. Most endpoints will define a default value, such as 1000.
   start - a date time for start, if none specified then from the start of collection.
   end - a date time for end, if none specified then to the end of the collection.
 - timeout_millis - the number of milliseconds that hydra will wait for a full result set from the query
 
+NOTE: if end < start, then the query is a descending order query.
+
+## Errors
+
+Ditto HTTP API errors are indicated with an HTTP Status Code and with a JSON response body containing an object with a single "error" key. This Error object contains the following fields:
+
+- error.code - The HTTP Status Code for
+- error.message - A short description of the error
+- error.data - An optional object which contains further elaboration about the error
+
+## Generating an Actor ID
+
+```python
+>>> import base64
+>>> site_id = 5
+>>> epoch = 0
+>>> site_id_bytes = site_id.to_bytes(8,'big')
+>>> epoch_bytes = epoch.to_bytes(8, 'big')
+>>> actor_id_bytes = site_id_bytes + epoch_bytes
+>>> actor_id_bytes
+b'\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00'
+>>> base64.b64encode(actor_id_bytes)
+b'AAAAAAAAAAUAAAAAAAAAAA=='
+```
 
 ## Ditto API Resources
 
 The Ditto HTTP API follows a RESTful pattern and is organized into several resources. API Resources typically map to the key elements of the [Ditto Data Model](https://www.ditto.live/docs/concepts/data-model). Applications may contain one or more `Collection`s of `Documents` or `TimeSeries` of `Event`s. JSON is used as the default representation for individual resources, and will be indicated by the `Content-Type` HTTP Header. Resources which are best represented by a sequence or stream of items are represented by [JSONlines](https://jsonlines.org), that is new line delimited JSON. This will be indicated by the MIME type `application/json-l`. UTF-8 encoding is used and required unless otherwise indicated. Binary data should be Base64 encoded. Where alternative representations are desired, the API Client may use the `Accept` HTTP Header to indicate this in the Request.
 
-
+<!-- Currently, Collections and TimeSeries can't be edited directly as top level API resources; only operations on the underlying documents are supported. Collections and TimeSeries are created implicitly by inserting into them. Later, we may add the ability to create, configure, and delete entire collections and timeseries directly.-->
 
 ### Collection and Document Resources
+
+#### URL Template: `/api/v1/collections`
+
+_Reserved for future use_
 
 #### URL TEMPLATE: `/api/v1/collections/{collection_name}/documents`
 
@@ -69,6 +114,8 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   find: "color=='red'"
   ```
 
+  <!-- Propose also support GET request body parsing in the future as this may be easier to pass complex query logic -->
+
   Response
 
   ```
@@ -79,8 +126,7 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   {"bar": 2000, "color": "red"}
   ```
 
-  #### URL TEMPLATE: `/api/v1/collections/{collection_name}/documents/{document_id}`
-
+#### URL TEMPLATE: `/api/v1/collections/{collection_name}/documents/{document_id}`
 
 - POST - Insert a new document into a collection with given ID {id}.
 
@@ -144,8 +190,11 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   {"txn_id": 9}
   ```
 
-
 ### TimeSeries and Events Resources
+
+#### URL Template: `/api/v1/timeseries`
+
+_Reserved for future use_
 
 #### URL Template: `/api/v1/timeseries/<timeseries_id>/events`
 
@@ -188,7 +237,7 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   - end (rfc3339 string, optional) - The earliest time AFTER the queried interval. Defaults to current time.
   - limit (number, optional) - The maximum number of events to return. Defaults to 1000.
   - filter (string, optional) - A dittoQL string
-  - timeout_millis - the timeout, in milliseconds
+  - timeout_millis (number, optional) - the timeout, in milliseconds
 
   _Note: the `null` parameters are simply to show which parameters could be provided. These keys don't actually need to be present._
 
@@ -200,6 +249,21 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   Content-Type: application/json
   X-HYDRA-VERSION: 7
   ```
+
+  Or you can provide the query in the body of the request as a JSON object. If you want to sort your results using order-by then you must provide the query in the request body. JSON Query Object parameters are as above with the addition of a new parameter `order_by` which is an array of pairs `[path, direction]` where the pair has to be encoded as an array in JSON (which has no tuple variant.) `Path` is ditto_ql expression. Direction must be an integer where a negative integer indicates sort Descending, and a positive value means sort Ascending.
+
+Example JSON
+
+```
+{
+  "start": "2021-04-20T00:00:00.0Z"
+  "end": null,
+  "limit": 500,
+  "filter": "a >= 1",
+  "timeout_millis": 500,
+  "order_by": [["a.b", -1], ["c", 1]]
+}
+```
 
   Response
 
@@ -241,37 +305,41 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
   {"txn_id": 15}
   ```
 
-#### URL Template: `/api/v1/timeseries/<timeseries_id>/distinct_value`
+#### URL Template: `/api/v1/timeseries/<timeseries_id>/distinct_values`
 
-- GET - Query for the distinct values in a timeseries, within a range of events in a TimeSeries using a half-open interval `[start, end)`. Returns a *single document* containing the aggregated paths and their distinct values.  Paths are specified as json arrays of strings. This query *expects a json body* in the following format:
+** DEPRECATED use v2 instead **
+
+- GET - Query for the distinct values in a timeseries, within a range of events in a TimeSeries using a half-open interval `[start, end)` (optional). Returns a single document containing the paths and their distinct values.  Paths are specified as json arrays of strings. This query expects a body of json in the following format:
 
   ```
-  {"start":null,"end":null,"paths":[["minutes"]],"timeout_millis":null}
+  { "start": null, "end": null, "paths": [["minutes"], ["nested", "device_id"]] }
   ```
-  Parameters
 
+  Parameters:
   - start (rfc3339 string, optional) - The earliest time that will be included. Defaults to 1970-01-01T00:00:0Z (epoch start).
   - end (rfc3339 string, optional) - The earliest time AFTER the queried interval. Defaults to current time.
-  - paths (array(array(string))) - Event paths for which the distict values should be calculated.
-  - timeout_millis (number, optional) - Request will stop if it exceeds this time (defaults to 10_000).
+  - paths (list) - A list of DittoQl paths to get distinct values for. See Supported Paths section below.
+  - timeout_millis (number, optional) - the timeout, in milliseconds
 
-
-  ```
-  GET /api/v1/timeseries/my-time-series/distinct_value HTTP/1.1
-  Accept: application/json-l
-  Content-Type: application/json
-  X-HYDRA-VERSION: 7
-
-  {"start": null, "end": null,"paths":[["parent", "child", "grandchild"]],"timeout_millis":null}
-  ```
+  Supported paths:
+  - Field access. Eg. `fieldA`, `fieldA.fieldB`.
+  - No other access methods are supported.
 
   Response
 
+  The response will contain an object where the keys are the json encoded paths from the request. And their values are the unique values at the respective paths.
+  Note that only primitive values are returned distinctly. Any arrays or objects present at the specified path will appear in the result as an empty array `{}` or object `{}` respectively.
+
   ```
   HTTP/1.1 200 OK
-  Content-Type: application/json-l
+  Content-Type: application/json
   X-HYDRA-VERSION: 7
-  {"item":{"[\"parent\", \"child\", \"grandchild\"]":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59]}}
+  {
+    "item": {
+      "[\"minutes\"]: [0, 1, 2],
+      "[\"nested\", "\"device_id"\"]": ["tag1", "tag2"]
+    }
+  }
 
   ```
   Note also the X-HYDRA-VERSION value is included the Response Header
@@ -283,9 +351,76 @@ The Ditto HTTP API follows a RESTful pattern and is organized into several resou
 
   ```
 
+#### URL Template: `/api/v2/timeseries/<timeseries_id>/distinct_values`
+
+- GET - Query for the distinct values in a timeseries, within a range of events in a TimeSeries using a half-open interval `[start, end)` (optional). Returns a single document containing the paths and their distinct values.  Paths are specified as json arrays of strings. This query expects a body of json in the following format:
+
+  ```
+  {
+    "start": null,
+    "end": null,
+    "paths": [
+      "minutes",
+      "nested.device_id",
+      "nested.tags[*]",
+      "nested",
+      "nested.tags"
+    ]
+  }
+  ```
+
+  Parameters
+
+  - start (rfc3339 string, optional) - The earliest time that will be included. Defaults to 1970-01-01T00:00:0Z (epoch start).
+  - end (rfc3339 string, optional) - The earliest time AFTER the queried interval. Defaults to current time.
+  - paths (list) - A list of DittoQl paths to get distinct values for. See Supported Paths section below.
+  - timeout_millis (number, optional) - the timeout, in milliseconds
+
+  Supported paths
+
+  - Field access. Eg. `fieldA`, `fieldA.fieldB`.
+  - Array projection. Eg. `fieldA.arrayB[*]`, `fieldA.arrayB[*].fieldC`.
+  - No other access methods are supported.
+
+  Response
+
+  The response will contain an object where the keys are the requested paths (same format as the request) and their values are the unique values at the respective paths.
+  Note that only primitive values are returned distinctly. Any arrays or objects present at the specified path will appear in the result as an empty array `{}` or object `{}` respectively.
+
+  ```
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  X-HYDRA-VERSION: 7
+  {
+    "item": {
+      "minutes": [1, 2, 3],
+      "nested.device_id": ["device1", "device2"],
+      "nested.tags[*]": ["tag1", "tag2"],
+      "nested": [{}],
+      "nested.tags": [[]],
+    }
+  }
+
+  ```
+  Note also the X-HYDRA-VERSION value is included the Response Header
+
+  If there is an error once the stream has begun, it is communicated with a final json lines value, for example:
+
+  ```
+  {"error": "Timeout"}
+
+  ```
 ### Events
 
-An Event is the fundamental element of a TimeSeries. It consists of a timestamp and a document. The JSON API interface may optionally not require the series_id or time value.  Following is the JSON schema for an event:
+#### URL Template: `/api/v1/events`
+
+_Reserved for future use_
+
+## JSON Representation of Key Resources
+
+### Event
+
+An Event is the fundamental element of a TimeSeries. It consists of a timestamp and a document. The JSON API interface may optionally not require the series_id or time value.
 
 ```json
 {
@@ -314,13 +449,11 @@ An Event is the fundamental element of a TimeSeries. It consists of a timestamp 
 
 ### Datetime
 
-Datetimes are used to indicate when a particular event occurred. 
+Datetimes are used to indicate when a particular event occurred. In a binary context, timestamps are stored with the [TAI64N]() format, but in a JSON context RFC 3339 formatted strings are used, including the fractional seconds. If the fractional seconds are not supplied, 0 nanoseconds are assumed. If an offset (timezone) is not supplied, UTC is assumed. The term `Datetime` is used to represent the RFC3339-formated String representation, while `Timestamp` is used to represent the binary encoding. The two types are generally inter-convertable. However, some client libraries may not fully preserve the full resolution of the `Datetime` during round trip serialization.
 
-They are encoded as RFC 3339 formatted strings, including the fractional seconds. If the fractional seconds are not supplied, 0 nanoseconds are assumed. If an offset (timezone) is not supplied, UTC is assumed. 
+Queries which require an interval of time to be specified, or events where full nanosecond resolution is not required, can "truncate" the `Datetime` by rounding down to the start of the period of interest and framing the query as a comparison. For example, when one only cares about events with hourly resolution, an event which occurred at T17:36:12.12345 can be "rounded" to T17:00:00.0. The right-most non-zero digit of the Datetime or Timestamp determines the resolution of the Timeseries.
 
-Queries which require an interval of time to be specified, or events where full nanosecond resolution is not required, can "truncate" the `Datetime` by rounding down to the start of the period of interest and framing the query as a comparison. For example, we one only cares about events with hourly resolution, an event which occurred at T17:36:12.12345 can be "rounded" to T17:00:00.0. The right-most non-zero digit of the Datetime or Timestamp determines the resolution of the Timeseries.
-
-The JSON schema for a `DateTime` String is shown below:
+The JSON Validation Schema for a `DateTime` String is shown below:
 
 ```json
 {
@@ -350,5 +483,14 @@ The JSON schema for a `DateTime` String is shown below:
     },
     "required": ["year", "month", "day", "hour", "minute", "second"]
   }
+}
+```
+
+`Timestamp` has a binary representation which is more compact (12 bytes), shown below.
+
+```rust
+struct Timestamp {
+    pub epoch: i64,
+    pub nanos: u32
 }
 ```

--- a/docs/concepts/http.md
+++ b/docs/concepts/http.md
@@ -1,4 +1,4 @@
-# Ditto HTTP API Reference
+# HTTP API Reference
 
 <!-- This document is intended to serve as a public facing guide to the entire HTTP API at the time we deliver Particle phase 1. Items for future work or discussion will be called out in comments like this. -->
 

--- a/docs/concepts/http.md
+++ b/docs/concepts/http.md
@@ -46,8 +46,8 @@ Ditto's HTTP API uses HTTP Methods (aka "verbs") to distinguish between typical 
 
 - find - A JMESPath formatted string used to filter the target collection
 - limit - Used to limit the number of resources returned in a query. Most endpoints will define a default value, such as 1000.
-  start - a date time for start, if none specified then from the start of collection.
-  end - a date time for end, if none specified then to the end of the collection.
+- start - a date time for start, if none specified then from the start of collection.
+- end - a date time for end, if none specified then to the end of the collection.
 - timeout_millis - the number of milliseconds that hydra will wait for a full result set from the query
 
 NOTE: if end < start, then the query is a descending order query.

--- a/docs/concepts/http.md
+++ b/docs/concepts/http.md
@@ -232,6 +232,14 @@ _Reserved for future use_
   - limit (number, optional) - The maximum number of events to return. Defaults to 1000.
   - filter (string, optional) - A dittoQL string
   - timeout_millis (number, optional) - the timeout, in milliseconds
+  - describe - a boolean that when absent or false does nothing, but when `true` rather than performing the query will return a single item that contains information about the query plan that would be executed for the given query
+
+Here is an example of the `describe` parameter output:
+
+```
+curl -X GET "localhost:8000/00000000-0000-4000-8000-000000000000/api/v1/timeseries/0/events?describe=true&filter=device==1"
+{"item": {"index_scan":{"eq":1,"path":["device"]}}}
+```
 
   _Note: the `null` parameters are simply to show which parameters could be provided. These keys don't actually need to be present._
 

--- a/docs/concepts/insert-update-remove.mdx
+++ b/docs/concepts/insert-update-remove.mdx
@@ -22,6 +22,7 @@ Insert data into a collection with the insert function. It will return the `_id`
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -112,6 +113,18 @@ DocumentId doc_id = ditto.store.collection("people").insert(content);
   ```
 
 </TabItem>
+<TabItem value="http">
+
+  ```bash
+  curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "Susan", "age": 31}'
+  ```
+
+  NOTE: The HTTP API does not return the id, but a `txn_id` which can be used to request the document `_id`. See [HTTP API Reference](/concepts/http#transactions) for more details.
+
+</TabItem>
 </Tabs>
 
 ### Inserting with a specific `_id`
@@ -130,6 +143,7 @@ There are times where you want to specify the `_id` of the document before inser
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -216,6 +230,17 @@ ditto.store.collection("people").insert({{"_id", "123abc"}, { "name", "Susan" },
   ```
 
 </TabItem>
+
+<TabItem value="http">
+
+  ```bash
+  curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/123abc' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "Susan", "age": 31}'
+  ```
+
+</TabItem>
 </Tabs>
 
 ### Default Data
@@ -243,6 +268,7 @@ In the above example, both Device A and B want to preserve the change by Device 
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -326,6 +352,9 @@ DocumentId doc_id = ditto.store.collection("people")
   ```
 
 </TabItem>
+<TabItem value="http">
+  Default data is not supported by the HTTP API.
+</TabItem>
 </Tabs>
 
 
@@ -360,6 +389,7 @@ Arrays
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -537,7 +567,15 @@ ditto.store().collection("people")?.update(|x|{
   }
 })?;
 ```
+</TabItem>
+<TabItem value="http">
 
+  ```bash
+  curl -X POST 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/<DOC_ID>' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"age": 32, "friends": ["Susan"]}'
+  ```
 </TabItem>
 </Tabs>
 
@@ -575,6 +613,7 @@ An upsert with a merge strategy will set the properties on the document that mat
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -676,6 +715,9 @@ ditto.store().collection("people")?.insert_with_strategy(
 ```
 
 </TabItem>
+<TabItem value="http">
+  Insert with Strategy is not supported by the HTTP API.
+</TabItem>
 </Tabs>
 
 Now the document will look like this:
@@ -714,6 +756,7 @@ An overwrite strategy will remove the document if it exists and recreate with it
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -815,6 +858,10 @@ ditto.store().collection("people")?.insert_with_strategy(
 ```
 
 </TabItem>
+
+<TabItem value="http">
+  Insert with Strategy is not supported by the HTTP API.
+</TabItem>
 </Tabs>
 
 The final document will look like the following below. Since the `_id` matched, the document was removed and reinserted.
@@ -853,6 +900,7 @@ The `.insertIfAbsent` strategy is quite straight forward. If the `_id` of the pa
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -954,6 +1002,9 @@ ditto.store().collection("people")?.insert_with_strategy(
 ```
 
 </TabItem>
+<TabItem value="http">
+  Insert with Strategy is not supported by the HTTP API.
+</TabItem>
 </Tabs>
 
 Thus using our example, the document is left unchanged. 
@@ -993,6 +1044,7 @@ The `insertDefaultIfAbsent` is a strategy that is best for _placeholder_ data. I
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -1094,6 +1146,9 @@ ditto.store().collection("people")?.insert_with_strategy(
 ```
 
 </TabItem>
+<TabItem value="http">
+  Insert with Strategy is not supported by the HTTP API.
+</TabItem>
 </Tabs>
 
 Thus using our example, the document is left unchanged. 
@@ -1170,6 +1225,7 @@ ditto.store.collection('cars').update((mutableDoc) => {
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -1229,6 +1285,15 @@ ditto.store.collection("people").find_by_id(docId).remove();
   ```
 
 </TabItem>
+<TabItem value="http">
+
+  ```bash
+  curl -X DELETE 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/<doc_id>' \
+    --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
+    --header 'Content-Type: application/json' \
+    --data-raw '{"name": "Susan", "age": 31}'
+  ```
+</TabItem>
 </Tabs>
 
 ### Removing by query
@@ -1248,6 +1313,7 @@ You can also remove several documents with a query string. This example will rem
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -1307,6 +1373,10 @@ ditto.store.collection("people").find("age <= 32").remove();
   ```
 
 </TabItem>
+<TabItem value="http">
+  Delete by query is not supported by the HTTP API.
+</TabItem>
+
 </Tabs>
 
 ## Evicting Data
@@ -1330,6 +1400,7 @@ The API is extremely similar to the `remove()` API, however it uses `evict()` in
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -1389,4 +1460,9 @@ ditto.store.collection("people").find("age <= 32").evict();
   ```
 
 </TabItem>
+
+<TabItem value="http">
+  Evict is not supported by the HTTP API.
+</TabItem>
+
 </Tabs>

--- a/docs/concepts/insert-update-remove.mdx
+++ b/docs/concepts/insert-update-remove.mdx
@@ -1290,8 +1290,7 @@ ditto.store.collection("people").find_by_id(docId).remove();
   ```bash
   curl -X DELETE 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents/<doc_id>' \
     --header 'X-HYDRA-CLIENT-ID: AAAAAAAAAAAAAAAAAAAABQ==' \
-    --header 'Content-Type: application/json' \
-    --data-raw '{"name": "Susan", "age": 31}'
+    --header 'Content-Type: application/json' 
   ```
 </TabItem>
 </Tabs>

--- a/docs/concepts/querying.md
+++ b/docs/concepts/querying.md
@@ -20,6 +20,7 @@ Ditto provides a robust query engine that supports different filter operations. 
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'}
   ]
 }>
 <TabItem value="javascript">
@@ -97,6 +98,13 @@ let docs = ditto.store().collection("people")
 .find("favoriteBooks[0].title == \'The Great Gatsby\'")
 .exec()?;
 ```
+
+</TabItem>
+<TabItem value="http">
+
+  ```bash
+  curl -X GET 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents?find=favoriteBooks[0].title=="The Great Gatsby"'
+  ```
 
 </TabItem>
 </Tabs>
@@ -416,6 +424,7 @@ The following example will sort on documents that have a mileage property
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -497,6 +506,9 @@ let results = ditto.store().collection("cars").find("color == \'red\'")
   .exec()?;
 ```
 </TabItem>
+<TabItem value="http">
+Arbitrary sorting is not supported by the HTTP API. If you're interested in sorting by datetime, see [HTTP API Reference](/concepts/http#common-query-parameters).
+</TabItem>
 </Tabs>
 
 ## Limit 
@@ -515,6 +527,7 @@ There are times where you need to limit the number of results that a query. Call
     {label: 'C#', value: 'csharp'},
     {label: 'C++', value: 'cpp'},
     {label: 'Rust', value: 'rust'},
+    {label: 'HTTP', value: 'http'},
   ]
 }>
 <TabItem value="javascript">
@@ -599,6 +612,13 @@ let results = ditto.store().collection("cars").find("color == \'red\'")
   .limit(100)
   .exec()?;
 ```
+
+</TabItem>
+<TabItem value="http">
+
+  ```bash
+  curl -X GET 'https://<CLOUD_ENDPOINT>/api/v1/collections/people/documents?find=color=="red"&limit=100'
+  ```
 
 </TabItem>
 </Tabs>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,3 +6,6 @@
 :root {
   --ifm-heading-font-family: 'Inter'
 }
+.prose tbody td:first-child {
+  padding-left:1.25em; 
+}


### PR DESCRIPTION
Ready for review
- [x] Moves internal HTTP docs from @getditto/ditto/docs/http-api/index.md to this repository
- [x] Adds HTTP tab to the Data model section
- [x] Removes deprecated v1 timeseries API
- [x] Adds HTTP tab to Insert, Update, Remove
- [x] Adds HTTP tab to Querying
- [x] Expands on the Transactions section to include a `txn_id` example

https://www.loom.com/share/508c26da4d78468ab0c0de106f77f57c