### PR TITLE
Remove references to `insert` and `insertWithStrategy`

### DIFF
--- a/docs/concepts/data-model.mdx
+++ b/docs/concepts/data-model.mdx
@@ -97,7 +97,20 @@ let cars_collection = store.collection("cars")?;
 A Ditto document is a schema flexible unit of data in Ditto. If collections are similar to tables, then a document is similar to a row. A document, at its highest level, is a map that can contain arbitrarily nested keys and values. Each document has a primary key, often referred to as an id.
 
 ## Document `_id`, the Primary Key
-In order for documents to sync, each document must have a unique identifier which we refer to as the id. This is the primary key of the document and is not optional.
+In order for documents to sync, each document must have a unique identifier
+which we refer to as the id. This is the primary key of the document and is not
+optional.
+
+As an example, let's say we have a document in the `people` collection that looks like this:
+
+```jsonc
+{
+  "_id": "123abc",
+  "name": "Sam",
+  "age": 45,
+  "isOnline": false
+}
+```
 
 You can supply your own unique identifier when creating a document:
 
@@ -118,7 +131,7 @@ You can supply your own unique identifier when creating a document:
 <TabItem value="javascript">
 
 ```js
-let docId = ditto.store.collection("people").insert({
+let docId = ditto.store.collection("people").upsert({
     "_id": "123abc",
     "name": "Susan",
     "age": 31
@@ -130,7 +143,7 @@ console.log(docId) // "123abc"
 <TabItem value="swift">
 
 ```swift
-let docId = ditto.store["people"].insert([
+let docId = ditto.store["people"].upsert([
     "_id": "123abc"
     "name": "Susan",
     "age": 31
@@ -143,7 +156,7 @@ print(docId) // "123abc"
 
 ```objc
 NSString *docId = [[ditto.store collection:@"people"]
-                    insert:@{ @"_id": @"123abc" @"name": @"Susan", @"age": @31 }
+                    upsert:@{ @"_id": @"123abc" @"name": @"Susan", @"age": @31 }
                     isDefault:false
                     error:nil];
 NSLog(@"%@", docId); // => "123abc"
@@ -153,7 +166,7 @@ NSLog(@"%@", docId); // => "123abc"
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(
+val docId = ditto.store["people"].upsert(
     mapOf(
         "_id" to "123abc"
         "name" to "Susan",
@@ -172,7 +185,7 @@ Map<String, Object> content = new HashMap<>();
 content.put("_id", "123abc");
 content.put("name", "Susan");
 content.put("age", 31);
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+DittoDocumentID docId = ditto.store.collection("people").upsert(content);
 Log.d("Debug", docId); // => 123abc
 ```
 
@@ -187,7 +200,7 @@ var content = new Dictionary<string, object>
     { "name", "Susan" },
     { "age", 31 }
 };
-ditto.Store.Collection("people").Insert(content);
+ditto.Store.Collection("people").Upsert(content);
 docId; // => "123abc"
 ```
 
@@ -202,7 +215,7 @@ json person = json({
 });
 DocumentId doc_id = ditto.store
                          .collection("people")
-                         .insert(person);
+                         .upsert(person);
 ```
 
 </TabItem>
@@ -240,7 +253,7 @@ The id parameter is optional during insertion. If you do not supply a document `
 <TabItem value="javascript">
 
 ```js
-let docId = ditto.store.collection("people").insert({
+let docId = ditto.store.collection("people").upsert({
     "name": "Susan",
     "age": 31
 })
@@ -251,7 +264,7 @@ console.log(docId) // "507f191e810c19729de860ea"
 <TabItem value="swift">
 
 ```swift
-let docId = ditto.store["people"].insert([
+let docId = ditto.store["people"].upsert([
     "name": "Susan",
     "age": 31
 ])
@@ -263,7 +276,7 @@ print(docId) // "507f191e810c19729de860ea"
 
 ```objc
 NSString *docId = [[ditto.store collection:@"people"]
-                    insert:@{ @"name": @"Susan", @"age": @31 }
+                    upsert:@{ @"name": @"Susan", @"age": @31 }
                     isDefault:false
                     error:nil];
 NSLog(@"%@", docId); // => "507f191e810c19729de860ea"
@@ -273,7 +286,7 @@ NSLog(@"%@", docId); // => "507f191e810c19729de860ea"
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(
+val docId = ditto.store["people"].upsert(
     mapOf(
         "name" to "Susan",
         "age" to 31
@@ -290,7 +303,7 @@ docId // => "507f191e810c19729de860ea"
 Map<String, Object> content = new HashMap<>();
 content.put("name", "Susan");
 content.put("age", 31);
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+DittoDocumentID docId = ditto.store.collection("people").upsert(content);
 Log.d("Debug", docId); // => 507f191e810c19729de860ea
 ```
 
@@ -304,7 +317,7 @@ var content = new Dictionary<string, object>
     { "name", "Susan" },
     { "age", 31 }
 };
-ditto.Store.Collection("people").Insert(content);
+ditto.Store.Collection("people").Upsert(content);
 docId; // => "123abc"
 ```
 
@@ -318,7 +331,7 @@ json person = json({
 });
 DocumentId doc_id = ditto.store
                          .collection("people")
-                         .insert(person);
+                         .upsert(person);
 ```
 
 </TabItem>
@@ -358,7 +371,7 @@ You may have a data model where documents are considered unique due to two or mo
 <TabItem value="javascript">
 
 ```js
-let docId = ditto.store.collection("people").insert({
+let docId = ditto.store.collection("people").upsert({
     "_id": { "userId": "456abc", "workId": 789 }
     "name": "Susan",
     "age": 31
@@ -370,7 +383,7 @@ console.log(docId) // "{ "userId": "456abc", "workId": 789 }"
 <TabItem value="swift">
 
 ```swift
-let docId = ditto.store["people"].insert([
+let docId = ditto.store["people"].upsert([
     "_id": [ "userId": "456abc", "workId": 789 ]
     "name": "Susan",
     "age": 31
@@ -383,7 +396,7 @@ print(docId) // "[ "userId": "456abc", "workId": 789 ]"
 
 ```objc
 NSString *docId = [[ditto.store collection:@"people"]
-                    insert:@{ 
+                    upsert:@{ 
                       @"_id": @{ @"userId": "456abc": @"workId": @789 }
                       @"name": @"Susan", 
                       @"age": @31 }
@@ -396,7 +409,7 @@ NSLog(@"%@", docId); // => "NSDictionary @{ @"userId": "456abc": @"workId": @789
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(
+val docId = ditto.store["people"].upsert(
     mapOf(
         "_id": mapOf( "userId": "456abc", "workId": 789),
         "name" to "Susan",
@@ -419,7 +432,7 @@ Map<String, Object> content = new HashMap<>();
 content.put("_id", _id)
 content.put("name", "Susan");
 content.put("age", 31);
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+DittoDocumentID docId = ditto.store.collection("people").upsert(content);
 Log.d("Debug", docId); // => "_id.put("userId", "456abc"); _id.put("workId", 789);"
 ```
 
@@ -434,7 +447,7 @@ var content = new Dictionary<string, object>
     { "name", "Susan" },
     { "age", 31 }
 };
-ditto.Store.Collection("people").Insert(content);
+ditto.Store.Collection("people").Upsert(content);
 docId; // => "{{ "userId", "456abc" }, { "workId": 789 }}"
 ```
 
@@ -452,7 +465,7 @@ json person = json({
 });
 DocumentId doc_id = ditto.store
                          .collection("people")
-                         .insert(person);
+                         .upsert(person);
 ```
 
 </TabItem>
@@ -596,7 +609,7 @@ The following snippets show a various set of data types
 
 ```js
 // Insert JSON-compatible data into Ditto
-await ditto.store.collection('foo').insert({
+await ditto.store.collection('foo').upsert({
     value: {
         "boolean": true,
         "string": "Hello World",
@@ -613,7 +626,7 @@ await ditto.store.collection('foo').insert({
 
 ```swift
 // Insert JSON-compatible data into Ditto
-ditto.store["foo"].insert([
+ditto.store["foo"].upsert([
     "boolean": true,
     "string": "Hello World",
     "number": 10,
@@ -629,7 +642,7 @@ ditto.store["foo"].insert([
 ```objc
 // Insert JSON-compatible data into Ditto
 [[ditto.store collection:@"foo"]
-  insert:@{
+  upsert:@{
       @"boolean": @true,
       @"string": @"Hello World",
       @"number": @10,
@@ -645,7 +658,7 @@ ditto.store["foo"].insert([
 <TabItem value="kotlin">
 
 ```kotlin
-ditto.store["foo"].insert(mapOf(
+ditto.store["foo"].upsert(mapOf(
     "boolean" to true,
     "string" to "Hello World",
     "number" to 10,
@@ -669,7 +682,7 @@ innerMap.put("key", "value");
 content.put("map", innerMap);
 content.put("array", Arrays.asList(1, 2, 3));
 content.put("null", null);
-ditto.store.collection("foo").insert(content);
+ditto.store.collection("foo").upsert(content);
 ```
 
 </TabItem>
@@ -686,7 +699,7 @@ var content = new Dictionary<string, object>
     { "array", new int[] {1, 2, 3} },
     { "null", null }
 };
-ditto.Store.Collection("foo").Insert(content);
+ditto.Store.Collection("foo").Upsert(content);
 ```
 
 </TabItem>
@@ -694,7 +707,7 @@ ditto.Store.Collection("foo").Insert(content);
 
 ```cpp
 // Insert JSON-compatible data into Ditto
-ditto.store.collection("foo").insert({
+ditto.store.collection("foo").upsert({
     {"boolean", true},
     {"string", "Hello World"},
     {"number", 10},
@@ -804,7 +817,7 @@ let attachment = collection.newAttachment(
     metadata: metadata
 )!
 
-try! collection.insert(["some": "string", "my_attachment": attachment])
+try! collection.upsert(["some": "string", "my_attachment": attachment])
 
 // Later, find the document and the fetch the attachment
 
@@ -833,7 +846,7 @@ NSDictionary<NSString *, NSString *> *metadata = @{@"name": @"my_image.png"};
 DITAttachment *attachment = [collection newAttachment:myImageURL.path
                                              metadata:metadata];
 
-[collection insert:@{@"some": @"string", @"my_attachment": attachment} error:nil];
+[collection upsert:@{@"some": @"string", @"my_attachment": attachment} error:nil];
 
 // Later, find the document and the fetch the attachment
 
@@ -864,7 +877,7 @@ val attachmentStream =  context.assets.open("image.png")
 val metadata = mapOf("name" to "my_image.png")
 val attachment = coll.newAttachment(attachmentStream, metadata)
 
-val docID =  coll.insert(mapOf("some" to "string", "my_attachment" to attachment))
+val docID =  coll.upsert(mapOf("some" to "string", "my_attachment" to attachment))
 
 // Later, find the document and the fetch the attachment
 
@@ -895,7 +908,7 @@ DittoAttachment attachment = coll.newAttachment(attachmentStream, metadata);
 Map<String, Object> content = new HashMap<>();
 content.put("some", "string");
 content.put("my_attachment", attachment);
-DittoDocumentID docID = coll.insert(content);
+DittoDocumentID docID = coll.upsert(content);
 
 // Later, find the document and the fetch the attachment
 
@@ -927,7 +940,7 @@ var coll = ditto.Store.Collection("people");
 var path = "path/to/image.png";
 var metadata = new Dictionary<string, string> { { "name", "my_image.png" } };
 var attachment = coll.NewAttachment(path, metadata);
-var docID = coll.Insert(new Dictionary<string, object> { { "some", "string" }, { "my_attachment", attachment } });
+var docID = coll.Upsert(new Dictionary<string, object> { { "some", "string" }, { "my_attachment", attachment } });
 
 // Later, find the document and the fetch the attachment
 
@@ -957,7 +970,7 @@ std::map<std::string, std::string> metadata = {{"some", "string"}};
 Attachment attachment =
     collection.new_attachment(attachment_file_path, metadata);
 
-collection.insert({{"some", "string"}, {"my_attachment", attachment}});
+collection.upsert({{"some", "string"}, {"my_attachment", attachment}});
 
 // Later, find the document and the fetch the attachment
 
@@ -1048,7 +1061,7 @@ Once the value in the document is a counter, you can proceed to increment or dec
 <TabItem value="javascript">
 
 ```js
-let docID = ditto.store["people"].insert({
+let docID = ditto.store["people"].upsert({
     name: 'Frank',
     ownedCars: 0 // here 0 is a number
 })
@@ -1063,7 +1076,7 @@ ditto.store.collection('people').findByID(docID).update((mutableDoc) => {
 <TabItem value="swift">
 
 ```swift
-let docId = ditto.store["people"].insert([
+let docId = ditto.store["people"].upsert([
     "name": "Frank",
     "ownedCars": 0 // here 0 is a number
 ])
@@ -1079,7 +1092,7 @@ ditto.store.["people"].findByID(docId).update({ mutableDoc in
 
 ```objc
 NSString *docId = [[ditto.store collection:@"people"]
-                    insert:@{ @"model": @"Frank", @"ownedCars": @0 }
+                    upsert:@{ @"model": @"Frank", @"ownedCars": @0 }
                     isDefault:false
                     error:nil];
 
@@ -1093,7 +1106,7 @@ NSString *docId = [[ditto.store collection:@"people"]
 <TabItem value="kotlin">
 
 ```kotlin
-val docID = ditto.store["people"].insert(mapOf(
+val docID = ditto.store["people"].upsert(mapOf(
     "name" to "Frank",
     "ownedCars" to 0
 ))
@@ -1111,7 +1124,7 @@ ditto.store.collection("people").findByID(docID).update { mutableDoc ->
 Map<String, Object> content = new HashMap<>();
 content.put("name", "Frank");
 content.put("ownedCars", 0);
-DittoDocumentID docID = ditto.store.collection("people").insert(content);
+DittoDocumentID docID = ditto.store.collection("people").upsert(content);
 
 ditto.store.collection("people").findByID(docID).update(mutDoc -> {
     try {
@@ -1132,7 +1145,7 @@ var content = new Dictionary<string, object>
     { "name", "Frank" },
     { "ownedCars", 0 }
 };
-ditto.Store.Collection("people").Insert(content);
+ditto.Store.Collection("people").Upsert(content);
 ditto.Store.Collection("people").FindById(docId).Update((mutableDoc) => {
     mutableDoc["ownedCars"].ReplaceWithCounter();
     mutableDoc["ownedCars"].Increment(1);
@@ -1143,7 +1156,7 @@ ditto.Store.Collection("people").FindById(docId).Update((mutableDoc) => {
 <TabItem value="cpp">
 
 ```cpp
-DocumentId docID = ditto.store.collection("people").insert({
+DocumentId docID = ditto.store.collection("people").upsert({
     {"name", "Frank"},
     {"ownedCars", 0}
 };

--- a/docs/concepts/insert-update-remove.mdx
+++ b/docs/concepts/insert-update-remove.mdx
@@ -1,14 +1,16 @@
 ---
-title: 'Insert, Update and Remove'
+title: 'Upsert, Update and Remove'
 sidebar_position: 2
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-## Inserting Documents
+## Upserting Documents
 
-Insert data into a collection with the insert function. It will return the `_id` of the document that was inserted.
+ __Upserting__ describes a behavior where you would want to insert a document into a collection if the document `_id` does not not exist. However if the `_id` does exist in your local store, Ditto will update the document in place. 
+ 
+ Upsert data into a collection with the `upsert` function. If the document does not exist, it will return the `_id` of the new document that was created. 
 
 <Tabs
   groupId="programming-language"
@@ -27,7 +29,7 @@ Insert data into a collection with the insert function. It will return the `_id`
 <TabItem value="javascript">
 
 ```js
-const docID = await ditto.store.collection('people').insert({
+const docID = await ditto.store.collection('people').upsert({
     name: "Susan",
     age: 31
 })
@@ -37,8 +39,8 @@ const docID = await ditto.store.collection('people').insert({
 <TabItem value="swift">
 
 ```swift
-// Insert JSON-compatible data into Ditto
-let docId = ditto.store["people"].insert([
+// upsert JSON-compatible data into Ditto
+let docId = ditto.store["people"].upsert([
     "name": "Susan",
     "age": 31
 ])
@@ -48,9 +50,9 @@ let docId = ditto.store["people"].insert([
 <TabItem value="objc">
 
 ```objc
-// Insert JSON-compatible data into Ditto
+// upsert JSON-compatible data into Ditto
 DITDocumentID *docID = [[ditto.store collection:@"people"]
-     insert:@{ @"name": @"Susan", @"age": [NSNumber numberWithInt:31] }
+     upsert:@{ @"name": @"Susan", @"age": [NSNumber numberWithInt:31] }
      isDefault:false
      error:nil];
 ```
@@ -59,7 +61,7 @@ DITDocumentID *docID = [[ditto.store collection:@"people"]
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(mapOf(
+val docId = ditto.store["people"].upsert(mapOf(
     "name" to "Susan",
     "age" to 31
 ))
@@ -72,7 +74,7 @@ val docId = ditto.store["people"].insert(mapOf(
 Map<String, Object> content = new HashMap<>();
 content.put("name", "Susan");
 content.put("age", 31);
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+DittoDocumentID docId = ditto.store.collection("people").upsert(content);
 ```
 
 </TabItem>
@@ -84,7 +86,7 @@ var content = new Dictionary<string, object>
     { "name", "Susan" },
     { "age", 31 }
 };
-var docId = ditto.Store.Collection("people").Insert(content);
+var docId = ditto.Store.Collection("people").upsert(content);
 ```
 
 </TabItem>
@@ -95,7 +97,7 @@ json content = json({
     { "name", "Susan" },
     { "age", 31 }
 });
-DocumentId doc_id = ditto.store.collection("people").insert(content);
+DocumentId doc_id = ditto.store.collection("people").upsert(content);
 ```
 
 </TabItem>
@@ -107,16 +109,28 @@ DocumentId doc_id = ditto.store.collection("people").insert(content);
     "name": "Susan",
     "age": 31
   });
-  let doc_id = ditto.store().collection("people")?.insert(content, None, false)?;
+  let doc_id = ditto.store().collection("people")?.upsert(content, None, false)?;
 
   ```
 
 </TabItem>
 </Tabs>
 
-### Inserting with a specific `_id`
 
-There are times where you want to specify the `_id` of the document before insertion. Note that the `_id` is immutable. This means that you cannot change the `_id` once you have inserted the document.
+### Upserting with a specific `_id`
+
+There are times where you want to specify the `_id` of the document before upsertion. Note that the `_id` is immutable. This means that you cannot change the `_id` once you have upserted the document.
+
+As an example, let's say we have a document in the `people` collection that looks like this:
+
+```jsonc
+{
+  "_id": "123abc",
+  "name": "Sam",
+  "age": 45,
+  "isOnline": false
+}
+```
 
 <Tabs
   groupId="programming-language"
@@ -135,10 +149,10 @@ There are times where you want to specify the `_id` of the document before inser
 <TabItem value="javascript">
 
 ```js
-const docID = await ditto.store.collection('people').insert({
-    _id, "123abc",
-    name: "Susan", 
-    age: 31
+await ditto.store.collection('people').insertWithStrategy({
+  "_id": "123abc",
+  "name": "Joe",
+  "isOnline": true
 })
 ```
 
@@ -146,11 +160,10 @@ const docID = await ditto.store.collection('people').insert({
 <TabItem value="swift">
 
 ```swift
-// Insert JSON-compatible data into Ditto
-let docId = ditto.store["people"].insert([
-    "_id": "123abc",
-    "name": "Susan",
-    "age": 31
+try ditto.store["people"].insertWithStrategy([
+  "_id": "123abc",
+  "name": "Joe",
+  "isOnline": true
 ])
 ```
 
@@ -158,176 +171,98 @@ let docId = ditto.store["people"].insert([
 <TabItem value="objc">
 
 ```objc
-// Insert JSON-compatible data into Ditto
-DITDocumentID *docID = [[ditto.store collection:@"people"]
-     insert:@{ @"_id": "123abc", @"name": @"Susan", @"age": [NSNumber numberWithInt:31] }
-     isDefault:false
-     error:nil];
+DITCollection *collection = [ditto.store collection:@"people"];
+[collection upsert:@{
+    @"_id": @"123abc",
+    @"name": @"Joe",
+    @"isOnline": YES
+  }
+  withID:customID
+  error:nil];
 ```
 
 </TabItem>
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(mapOf(
-    "_id" to "123abc",
-    "name" to "Susan",
-    "age" to 31
-), DittoDocumentID("123abc"))
-
+ditto.store["people"].upsert([
+  "_id" to "123abc",
+  "name" to "Joe",
+  "isOnline" to true
+])
 ```
 
 </TabItem>
 <TabItem value="java">
 
 ```java
-Map<String, Object> content = new HashMap<>();
-content.put("_id", "123abc");
-content.put("name", "Susan");
-content.put("age", 31);
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+Map<String, Object> map = new HashMap();
+map.put('_id', "123abc")
+map.put('name', "Joe")
+map.put('isOnline', true)
+ditto.store.collection("people").upsert(content)
 ```
 
 </TabItem>
 <TabItem value="csharp">
 
 ```csharp
-var content = new Dictionary<string, object>
+ditto.Store.Collection("people").Upsert(
+  new Dictionary<string, object> { 
+      { "_id", "123abc" }, 
+      {"name", "Joe"}, 
+      {"isOnline", true} 
+    }, 
+    DittoWriteStrategy.Merge)
+```
+
+</TabItem>
+<TabItem value="cpp">
+
+```cpp
+ditto.store.collection("people").upsert(
+      {
+        {"_id", "123abc"},
+        {"name", "Joe"},
+        {"isOnline", true}
+      }, custom_id);
+```
+
+</TabItem>
+<TabItem value="rust">
+
+```rust
+ditto.store().collection("people")?.insert(
+        json!({
+          "_id": "123abc",
+          "name": "Joe",
+          "isOnline": true
+        })
+    )
+```
+
+</TabItem>
+</Tabs>
+
+Now the document will look like this:
+
+```jsonc
+// before
 {
-    { "_id_", "123abc" },
-    { "name", "Susan" },
-    { "age", 31 }
-};
-ditto.Store.Collection("people").Insert(content);
+  "_id": "123abc",
+  "name": "Sam",
+  "age": 45,
+  "isOnline": false
+}
+
+// after
+{
+  "_id": "123abc",
+  "name": "Joe", // updated 
+  "age": 45, // left alone, because the payload did not include this key
+  "isOnline": true  // update
+}
 ```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-ditto.store.collection("people").insert({{"_id", "123abc"}, { "name", "Susan" }, { "age", 31 }});
-```
-
-</TabItem>
-<TabItem value="rust">
-
-  ```rust
-  ditto.store().collection("people")?.insert(json!({"_id": DocumentId::new("123abc")?, "name": "Susan", "age": 31}), None, false)?;
-  ```
-
-</TabItem>
-</Tabs>
-
-### Default Data
-
-Default Data can be thought of as "placeholder" data.  Default Data is useful when your app needs to load "starter" data from an external data source, like from a backend API, on multiple devices without creating odd "overwriting" behavior.
-
-Ditto's approach to conflict resolution orders changes by time. In most situations, this leads to predictable behavior. However, if your application is inserting the same initial data into multiple devices, such as common data from a central backend API, this could result in overwriting later changes:
-
-1. Device A inserts a document `{"firstName": "Adam"}` at time = 0 after downloading from a central API.
-2. Device A updates the document to `{"firstName": "Max"}` at time = 1.
-3. Device B synchronizes with Device A receiving the document `{"firstName": "Max"}` at time = 2.
-4. Device B downloads the same document from the backend API `{"firstName": "Adam"}` and inserts at t = 3, which overwrites the previous change synced at time = 1.
-
-In the above example, both Device A and B want to preserve the change by Device A that occurred after downloading the common data. To do so, Ditto offers an additional parameter: isDefault.
-
-<Tabs
-  groupId="programming-language"
-  defaultValue="javascript"
-  values={[
-    {label: 'JavaScript', value: 'javascript'},
-    {label: 'Swift', value: 'swift'},
-    {label: 'Objective-C', value: 'objc'},
-    {label: 'Kotlin', value: 'kotlin'},
-    {label: 'Java', value: 'java'},
-    {label: 'C#', value: 'csharp'},
-    {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
-  ]
-}>
-<TabItem value="javascript">
-
-```js
-const docID = await ditto.store.collection('people').insert({
-    _id: new DocumentID(123),
-    name: "Susan",
-    age: 31
-}, { isDefault: true })
-```
-
-</TabItem>
-<TabItem value="swift">
-
-```swift
-let docId = ditto.store.collection("people").insert([
-    "name": "Susan",
-    "age": 31
-], isDefault: true)
-```
-
-</TabItem>
-<TabItem value="objc">
-
-```objc
-DITDocumentID *docID = [[ditto.store collection:@"people"]
-     insert:@{ @"name": @"Susan", @"age": [NSNumber numberWithInt:31] }
-     isDefault:true
-     error:nil];
-```
-
-</TabItem>
-<TabItem value="kotlin">
-
-```kotlin
-val docId = ditto.store.collection("people").insert(mapOf(
-    "name" to "Susan",
-    "age" to 31
-), isDefault: true)
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-Map<String, Object> content = new HashMap<>();
-content.put("name", "Susan");
-content.put("age", 31);
-DittoDocumentID docId = ditto.store
-                             .collection("people")
-                             .insert(content, new DittoDocumentID("doc-id"), true);
-```
-
-</TabItem>
-<TabItem value="csharp">
-
-```csharp
-DittoDocumentID docID = ditto.Store
-                        .Collection("people")
-                        .Insert(
-                            {{"name", "Susan"}, {"age", 31}},
-                            new DittoDocumentID("doc-id"),
-                            true
-                        );
-```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-json content = json({{ "name", "Susan" }, { "age", 31 }}):
-DocumentId doc_id = ditto.store.collection("people")
-                               .insert(content, DocumentId("doc-id"), true);
-```
-</TabItem>
-<TabItem value="rust">
-
-  ```rust
-  ditto.store().collection("people")?.insert(json!({"_id": DocumentId::new("123abc")?, "name": "Susan", "age": 31}), None, true)?;
-  ```
-
-</TabItem>
-</Tabs>
-
 
 ## Updating Documents
 
@@ -345,7 +280,7 @@ Counters
 
 Arrays
 
-* Push - inserts a value on to the end of an array at the document's key
+* Push - upserts a value on to the end of an array at the document's key
 * Pop - removes a value at the end of an array at the document's key
 
 <Tabs
@@ -365,7 +300,7 @@ Arrays
 <TabItem value="javascript">
 
 ```js
-const docID = await ditto.store.collection('people').insert({
+const docID = await ditto.store.collection('people').upsert({
   name: "Frank",
   age: 31,
   ownedCars: 0,
@@ -385,7 +320,7 @@ await ditto.store.collection('people').findByID(docID).update((mutableDoc) => {
 <TabItem value="swift">
 
 ```swift
-let docId = ditto.store["people"].insert([
+let docId = ditto.store["people"].upsert([
     "name": "Frank",
     "age": 31,
     "ownedCars": 0,
@@ -404,7 +339,7 @@ ditto.store["people"].findByID(docId).update { mutableDoc in
 <TabItem value="objc">
 
 ```objc
-NSString *docId = [[ditto.store collection:@"people"] insert:@{
+NSString *docId = [[ditto.store collection:@"people"] upsert:@{
     @"name": @"Frank",
     @"age": [NSNumber numberWithInt:31],
     @"ownedCars": [NSNumber numberWithInt:0],
@@ -423,7 +358,7 @@ NSString *docId = [[ditto.store collection:@"people"] insert:@{
 <TabItem value="kotlin">
 
 ```kotlin
-val docId = ditto.store["people"].insert(mapOf(
+val docId = ditto.store["people"].upsert(mapOf(
     "name" to "Frank",
     "age" to 31,
     "ownedCars" to 0,
@@ -450,7 +385,7 @@ content.put("name", "Frank");
 content.put("age", 31);
 content.put("ownedCars", 0);
 content.put("friends", Arrays.asList());
-DittoDocumentID docId = ditto.store.collection("people").insert(content);
+DittoDocumentID docId = ditto.store.collection("people").upsert(content);
 
 ditto.store.collection("people").findByID(docId).update(doc -> {
     try {
@@ -476,7 +411,7 @@ var content = new Dictionary<string, object>
     { "friends", new List<object>() }
 };
 
-var docId = ditto.Store.Collection("people").Insert(content);
+var docId = ditto.Store.Collection("people").Upsert(content);
 ditto.Store.Collection("people").FindById(docId).Update((mutableDoc) => {
     mutableDoc["age"].Set(32);
     mutableDoc["ownedCars"].ReplaceWithCounter();
@@ -489,7 +424,7 @@ ditto.Store.Collection("people").FindById(docId).Update((mutableDoc) => {
 <TabItem value="cpp">
 
 ```cpp
-DocumentId doc_id = ditto.store.collection("people").insert({
+DocumentId doc_id = ditto.store.collection("people").upsert({
   {"name", "Frank"},
   {"age", 31},
   {"ownedCars", 0},
@@ -527,7 +462,7 @@ let frank = Person {
   friends: Vec::with_capacity(0)
 };
 
-let doc_id = ditto.store().collection("people")?.insert(frank, None, false)?;
+let doc_id = ditto.store().collection("people")?.upsert(frank, None, false)?;
 ditto.store().collection("people")?.update(|x|{
   if let Some(doc) = x {
       doc.set("age", 32).unwrap();
@@ -540,581 +475,6 @@ ditto.store().collection("people")?.update(|x|{
 
 </TabItem>
 </Tabs>
-
-## Upserting Documents 
-
-Because Ditto is an eventually consistent system, you will definitely run into situations where you need to __upsert__ documents. __Upserting__ describes a behavior where you would want to insert a document into a collection if the document `_id` does not not exist. However if the `_id` does exist in your local store, Ditto will `.update` the document in place. 
-
-
-To upsert a document, use the `collection.insertWithStrategy` function. You will need to provide the payload of the document that you'd like upsert as well as a `DittoWriteStrategy`. We offer __4 strategies for upserting documents.  
-
-As an example, let's say we have a document in the `people` collection that looks like this:
-
-```jsonc
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-```
-
-### Merge 
-
-An upsert with a merge strategy will set the properties on the document that match the existing document if it exists. Any properties that do not match are left alone.
-
-<Tabs
-  groupId="programming-language"
-  defaultValue="javascript"
-  values={[
-    {label: 'JavaScript', value: 'javascript'},
-    {label: 'Swift', value: 'swift'},
-    {label: 'Objective-C', value: 'objc'},
-    {label: 'Kotlin', value: 'kotlin'},
-    {label: 'Java', value: 'java'},
-    {label: 'C#', value: 'csharp'},
-    {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
-  ]
-}>
-<TabItem value="javascript">
-
-```js
-await ditto.store.collection('people').insertWithStrategy({
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-}, { writeStrategy: 'merge' })
-```
-
-</TabItem>
-<TabItem value="swift">
-
-```swift
-try ditto.store["people"].insertWithStrategy([
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-], writeStrategy: .merge)
-```
-
-</TabItem>
-<TabItem value="objc">
-
-```objc
-DITCollection *collection = [ditto.store collection:@"people"];
-[collection insert:@{
-    @"_id": @"123abc",
-    @"name": @"Joe",
-    @"isOnline": YES
-  }
-  withID:customID
-  writeStrategy:DITWriteStrategyMerge
-  error:nil];
-```
-
-</TabItem>
-<TabItem value="kotlin">
-
-```kotlin
-ditto.store["people"].insertWithStrategy([
-  "_id" to "123abc",
-  "name" to "Joe",
-  "isOnline" to true
-], DittoWriteStrategy.Merge)
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-Map<String, Object> map = new HashMap();
-map.put('_id', "123abc")
-map.put('name', "Joe")
-map.put('isOnline', true)
-ditto.store.collection("people").insertWithStrategy(content, null, DittoWriteStrategy.Merge)
-```
-
-</TabItem>
-<TabItem value="csharp">
-
-```csharp
-ditto.Store.Collection("people").InsertWithStrategy(
-  new Dictionary<string, object> { 
-      { "_id", "123abc" }, 
-      {"name", "Joe"}, 
-      {"isOnline", true} 
-    }, 
-    DittoWriteStrategy.Merge)
-```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-ditto.store.collection("people").insert_with_strategy(
-      {
-        {"_id", "123abc"},
-        {"name", "Joe"},
-        {"isOnline", true}
-      }, custom_id, WriteStrategy::merge);
-```
-
-</TabItem>
-<TabItem value="rust">
-
-```rust
-ditto.store().collection("people")?.insert_with_strategy(
-        json!({
-          "_id": "123abc",
-          "name": "Joe",
-          "isOnline": true
-        }),
-        None,
-        WriteStrategy::InsertIfAbsent,
-    )
-```
-
-</TabItem>
-</Tabs>
-
-Now the document will look like this:
-
-```jsonc
-// before
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-
-// after
-{
-  "_id": "123abc",
-  "name": "Joe", // updated 
-  "age": 45, // left alone, because the payload did not include this key
-  "isOnline": true  // update
-}
-```
-
-### Overwrite
-
-An overwrite strategy will remove the document if it exists and recreate with it's exact payload. You can think of it as calling `.remove` and `.insert` in one transaction.
-
-<Tabs
-  groupId="programming-language"
-  defaultValue="javascript"
-  values={[
-    {label: 'JavaScript', value: 'javascript'},
-    {label: 'Swift', value: 'swift'},
-    {label: 'Objective-C', value: 'objc'},
-    {label: 'Kotlin', value: 'kotlin'},
-    {label: 'Java', value: 'java'},
-    {label: 'C#', value: 'csharp'},
-    {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
-  ]
-}>
-<TabItem value="javascript">
-
-```js
-await ditto.store.collection('people').insertWithStrategy({
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-}, { writeStrategy: 'overwrite' })
-```
-
-</TabItem>
-<TabItem value="swift">
-
-```swift
-try ditto.store["people"].insertWithStrategy([
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-], writeStrategy: .overwrite)
-```
-
-</TabItem>
-<TabItem value="objc">
-
-```objc
-DITCollection *collection = [ditto.store collection:@"people"];
-[collection insert:@{
-    @"_id": @"123abc",
-    @"name": @"Joe",
-    @"isOnline": YES
-  }
-  withID:customID
-  writeStrategy:DITWriteStrategyOverwrite
-  error:nil];
-```
-
-</TabItem>
-<TabItem value="kotlin">
-
-```kotlin
-ditto.store["people"].insertWithStrategy([
-  "_id" to "123abc",
-  "name" to "Joe",
-  "isOnline" to true
-], DittoWriteStrategy.Overwrite)
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-Map<String, Object> map = new HashMap();
-map.put('_id', "123abc")
-map.put('name', "Joe")
-map.put('isOnline', true)
-ditto.store.collection("people").insertWithStrategy(content, null, DittoWriteStrategy.Overwrite)
-```
-
-</TabItem>
-<TabItem value="csharp">
-
-```csharp
-ditto.Store.Collection("people").InsertWithStrategy(
-  new Dictionary<string, object> { 
-      { "_id", "123abc" }, 
-      {"name", "Joe"}, 
-      {"isOnline", true} 
-    }, 
-    DittoWriteStrategy.Overwrite)
-```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-ditto.store.collection("people").insert_with_strategy(
-      {
-        {"_id", "123abc"},
-        {"name", "Joe"},
-        {"isOnline", true}
-      }, custom_id, WriteStrategy::overwrite);
-```
-
-</TabItem>
-<TabItem value="rust">
-
-```rust
-ditto.store().collection("people")?.insert_with_strategy(
-            json!({
-              "_id": "123abc",
-              "name": "Joe",
-              "isOnline": true
-            }),
-            None,
-            WriteStrategy::Merge,
-        )
-```
-
-</TabItem>
-</Tabs>
-
-The final document will look like the following below. Since the `_id` matched, the document was removed and reinserted.
-
-```json
-// before
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-
-// after
-{
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-}
-```
-
-### Insert If Absent
-
-The `.insertIfAbsent` strategy is quite straight forward. If the `_id` of the payload matched, then the document will not be inserted. If the document with the same `_id` does not exist, then the payload will be inserted. 
-
-
-<Tabs
-  groupId="programming-language"
-  defaultValue="javascript"
-  values={[
-    {label: 'JavaScript', value: 'javascript'},
-    {label: 'Swift', value: 'swift'},
-    {label: 'Objective-C', value: 'objc'},
-    {label: 'Kotlin', value: 'kotlin'},
-    {label: 'Java', value: 'java'},
-    {label: 'C#', value: 'csharp'},
-    {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
-  ]
-}>
-<TabItem value="javascript">
-
-```js
-await ditto.store.collection('people').insertWithStrategy({
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-}, { writeStrategy: 'insertIfAbsent' })
-```
-
-</TabItem>
-<TabItem value="swift">
-
-```swift
-try ditto.store["people"].insertWithStrategy([
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-], writeStrategy: .insertIfAbsent)
-```
-
-</TabItem>
-<TabItem value="objc">
-
-```objc
-DITCollection *collection = [ditto.store collection:@"people"];
-[collection insert:@{
-    @"_id": @"123abc",
-    @"name": @"Joe",
-    @"isOnline": YES
-  }
-  withID:customID
-  writeStrategy:DITWriteStrategyInsertIfAbsent
-  error:nil];
-```
-
-</TabItem>
-<TabItem value="kotlin">
-
-```kotlin
-ditto.store["people"].insertWithStrategy([
-  "_id" to "123abc",
-  "name" to "Joe",
-  "isOnline" to true
-], DittoWriteStrategy.InsertIfAbsent)
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-Map<String, Object> map = new HashMap();
-map.put('_id', "123abc")
-map.put('name', "Joe")
-map.put('isOnline', true)
-ditto.store.collection("people").insertWithStrategy(content, null, DittoWriteStrategy.InsertIfAbsent)
-```
-
-</TabItem>
-<TabItem value="csharp">
-
-```csharp
-ditto.Store.Collection("people").InsertWithStrategy(
-  new Dictionary<string, object> { 
-      { "_id", "123abc" }, 
-      {"name", "Joe"}, 
-      {"isOnline", true} 
-    }, 
-    DittoWriteStrategy.InsertIfAbsent)
-```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-ditto.store.collection("people").insert_with_strategy(
-      {
-        {"_id", "123abc"},
-        {"name", "Joe"},
-        {"isOnline", true}
-      }, custom_id, WriteStrategy::insertIfAbsent);
-```
-
-</TabItem>
-<TabItem value="rust">
-
-```rust
-ditto.store().collection("people")?.insert_with_strategy(
-          json!({
-            "_id": "123abc",
-            "name": "Joe",
-            "isOnline": true
-          }),
-          None,
-          WriteStrategy::InsertIfAbsent,
-      )
-```
-
-</TabItem>
-</Tabs>
-
-Thus using our example, the document is left unchanged. 
-
-```json
-// before
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-
-// after
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-```
-
-### Insert Default If Absent
-
-The `insertDefaultIfAbsent` is a strategy that is best for _placeholder_ data. If a document does not exist, the payload will be inserted that will not overwrite other peer's changes when they sync. 
-
-
-<Tabs
-  groupId="programming-language"
-  defaultValue="javascript"
-  values={[
-    {label: 'JavaScript', value: 'javascript'},
-    {label: 'Swift', value: 'swift'},
-    {label: 'Objective-C', value: 'objc'},
-    {label: 'Kotlin', value: 'kotlin'},
-    {label: 'Java', value: 'java'},
-    {label: 'C#', value: 'csharp'},
-    {label: 'C++', value: 'cpp'},
-    {label: 'Rust', value: 'rust'},
-  ]
-}>
-<TabItem value="javascript">
-
-```js
-await ditto.store.collection('people').insertWithStrategy({
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-}, { writeStrategy: 'insertDefaultIfAbsent' })
-```
-
-</TabItem>
-<TabItem value="swift">
-
-```swift
-try ditto.store["people"].insertWithStrategy([
-  "_id": "123abc",
-  "name": "Joe",
-  "isOnline": true
-], writeStrategy: .insertDefaultIfAbsent)
-```
-
-</TabItem>
-<TabItem value="objc">
-
-```objc
-DITCollection *collection = [ditto.store collection:@"people"];
-[collection insert:@{
-    @"_id": @"123abc",
-    @"name": @"Joe",
-    @"isOnline": YES
-  }
-  withID:customID
-  writeStrategy:DITWriteStrategyInsertDefaultIfAbsent
-  error:nil];
-```
-
-</TabItem>
-<TabItem value="kotlin">
-
-```kotlin
-ditto.store["people"].insertWithStrategy([
-  "_id" to "123abc",
-  "name" to "Joe",
-  "isOnline" to true
-], DittoWriteStrategy.InsertDefaultIfAbsent)
-```
-
-</TabItem>
-<TabItem value="java">
-
-```java
-Map<String, Object> map = new HashMap();
-map.put('_id', "123abc")
-map.put('name', "Joe")
-map.put('isOnline', true)
-ditto.store.collection("people").insertWithStrategy(content, null, DittoWriteStrategy.InsertDefaultIfAbsent)
-```
-
-</TabItem>
-<TabItem value="csharp">
-
-```csharp
-ditto.Store.Collection("people").InsertWithStrategy(
-  new Dictionary<string, object> { 
-      { "_id", "123abc" }, 
-      {"name", "Joe"}, 
-      {"isOnline", true} 
-    }, 
-    DittoWriteStrategy.InsertDefaultIfAbsent)
-```
-
-</TabItem>
-<TabItem value="cpp">
-
-```cpp
-ditto.store.collection("people").insert_with_strategy(
-      {
-        {"_id", "123abc"},
-        {"name", "Joe"},
-        {"isOnline", true}
-      }, custom_id, WriteStrategy::insertDefaultIfAbsent);
-```
-
-</TabItem>
-<TabItem value="rust">
-
-```rust
-ditto.store().collection("people")?.insert_with_strategy(
-          json!({
-            "_id": "123abc",
-            "name": "Joe",
-            "isOnline": true
-          }),
-          None,
-          WriteStrategy::InsertDefaultIfAbsent,
-      )
-```
-
-</TabItem>
-</Tabs>
-
-Thus using our example, the document is left unchanged. 
-
-```json
-// before
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-
-// after
-{
-  "_id": "123abc",
-  "name": "Sam",
-  "age": 45,
-  "isOnline": false
-}
-```
 
 ## Removing Documents
 
@@ -1154,7 +514,7 @@ ditto.store.collection('cars').update((mutableDoc) => {
 ```
 
 :::
-
+ 
 
 ### Removing by `_id`
 
@@ -1390,3 +750,115 @@ ditto.store.collection("people").find("age <= 32").evict();
 
 </TabItem>
 </Tabs>
+
+
+### Default Data
+
+Default Data can be thought of as "placeholder" data.  Default Data is useful when your app needs to load "starter" data from an external data source, like from a backend API, on multiple devices without creating odd "overwriting" behavior.
+
+Ditto's approach to conflict resolution orders changes by time. In most situations, this leads to predictable behavior. However, if your application is upserting the same initial data into multiple devices, such as common data from a central backend API, this could result in overwriting later changes:
+
+1. Device A upserts a document `{"firstName": "Adam"}` at time = 0 after downloading from a central API.
+2. Device A updates the document to `{"firstName": "Max"}` at time = 1.
+3. Device B synchronizes with Device A receiving the document `{"firstName": "Max"}` at time = 2.
+4. Device B downloads the same document from the backend API `{"firstName": "Adam"}` and upserts at t = 3, which overwrites the previous change synced at time = 1.
+
+In the above example, both Device A and B want to preserve the change by Device A that occurred after downloading the common data. To do so, Ditto offers an additional parameter: isDefault.
+
+<Tabs
+  groupId="programming-language"
+  defaultValue="javascript"
+  values={[
+    {label: 'JavaScript', value: 'javascript'},
+    {label: 'Swift', value: 'swift'},
+    {label: 'Objective-C', value: 'objc'},
+    {label: 'Kotlin', value: 'kotlin'},
+    {label: 'Java', value: 'java'},
+    {label: 'C#', value: 'csharp'},
+    {label: 'C++', value: 'cpp'},
+    {label: 'Rust', value: 'rust'},
+  ]
+}>
+<TabItem value="javascript">
+
+```js
+const docID = await ditto.store.collection('people').upsert({
+    _id: new DocumentID(123),
+    name: "Susan",
+    age: 31
+}, { isDefault: true })
+```
+
+</TabItem>
+<TabItem value="swift">
+
+```swift
+let docId = ditto.store.collection("people").upsert([
+    "name": "Susan",
+    "age": 31
+], isDefault: true)
+```
+
+</TabItem>
+<TabItem value="objc">
+
+```objc
+DITDocumentID *docID = [[ditto.store collection:@"people"]
+     upsert:@{ @"name": @"Susan", @"age": [NSNumber numberWithInt:31] }
+     isDefault:true
+     error:nil];
+```
+
+</TabItem>
+<TabItem value="kotlin">
+
+```kotlin
+val docId = ditto.store.collection("people").upsert(mapOf(
+    "name" to "Susan",
+    "age" to 31
+), isDefault: true)
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+Map<String, Object> content = new HashMap<>();
+content.put("name", "Susan");
+content.put("age", 31);
+DittoDocumentID docId = ditto.store
+                             .collection("people")
+                             .upsert(content, new DittoDocumentID("doc-id"), true);
+```
+
+</TabItem>
+<TabItem value="csharp">
+
+```csharp
+DittoDocumentID docID = ditto.Store
+                        .Collection("people")
+                        .upsert(
+                            {{"name", "Susan"}, {"age", 31}},
+                            new DittoDocumentID("doc-id"),
+                            true
+                        );
+```
+
+</TabItem>
+<TabItem value="cpp">
+
+```cpp
+json content = json({{ "name", "Susan" }, { "age", 31 }}):
+DocumentId doc_id = ditto.store.collection("people")
+                               .upsert(content, DocumentId("doc-id"), true);
+```
+</TabItem>
+<TabItem value="rust">
+
+  ```rust
+  ditto.store().collection("people")?.upsert(json!({"_id": DocumentId::new("123abc")?, "name": "Susan", "age": 31}), None, true)?;
+  ```
+
+</TabItem>
+</Tabs>
+

--- a/docs/concepts/syncing-data.md
+++ b/docs/concepts/syncing-data.md
@@ -305,7 +305,7 @@ const liveQuery = ditto.store.collection('cars')
 ```swift
 // --- Action somewhere in your application
 func userDidInsertCar() {
-    _ = ditto.store.collection("cars").insert([
+    _ = ditto.store.collection("cars").upsert([
         "model": "Ford",
         "color": "black"
     ])
@@ -324,7 +324,7 @@ let liveQuery = ditto.store.collection("cars").find("color == 'red'")
 ```objc
 // --- Action somewhere in your application
 -(void) userDidInsertCar() {
-    [[ditto.store collection:@"cars"] insert:@{
+    [[ditto.store collection:@"cars"] upsert:@{
         @"model": @"Ford",
         @"color": @"black"
     }];
@@ -344,7 +344,7 @@ DITLiveQuery *liveQuery = [[collection find:@"color == 'red'"]
 ```kotlin
 // --- Action somewhere in your application
 fun userDidInsertCar() {
-    ditto.store.collection("cars").insert(mapOf(
+    ditto.store.collection("cars").upsert(mapOf(
         "model" to "Ford",
         "color" to "black"
     ))
@@ -367,7 +367,7 @@ public void userDidInsertCar() {
     Map<String, Object> content = new HashMap<>();
     content.put("model", "Ford");
     content.put("color", "black");
-    ditto.store.collection("cars").insert(content);
+    ditto.store.collection("cars").upsert(content);
 }
 
 // --- Register live query to update UI
@@ -391,7 +391,7 @@ void user_did_insert_car()
         { "model", "Ford" },
         { "color", "black" }
     };
-    ditto.Store.Collection("cars").Insert(carsDocument);
+    ditto.Store.Collection("cars").Upsert(carsDocument);
 }
 
 // --- Register live query to update UI
@@ -407,7 +407,7 @@ var localLiveQuery = ditto.Store.Collection("cars").Find("color == 'red'").Obser
 ```cpp
 // --- Action somewhere in your application
 void user_did_insert_car() {
-    ditto.store.collection("cars").insert({
+    ditto.store.collection("cars").upsert({
         {"model", "Ford"},
         {"color", "black"}
     });

--- a/docs/tutorials/tasks/c-sharp-console/3-assigning-commands.md
+++ b/docs/tutorials/tasks/c-sharp-console/3-assigning-commands.md
@@ -11,11 +11,11 @@ Our application will continually ask for commands that we setup in the last sect
 1. To determine whether or not the while loop should run, we need an addition `static bool isAskedToExit = false`. If the user turns this to `true` via the `--exit` command, the while loop will stop and the application will exit.
 2. In each iteration of the while loop, we will need read the command from the user. In C#, we can use the `Console.ReadLine` API, which will prompt the user for a string entry. We can store this into `string command`.
 3. We can add a `switch` statement which will parse the correct command and react to the command.
-4. If the user types in `--insert`, we will parse out the string without the `--insert` command. We assume this string is the `body` for a new document. So we will call the `.insert` command with ditto via:
+4. If the user types in `--insert`, we will parse out the string without the `--insert` command. We assume this string is the `body` for a new document. So we will call the `.upsert` command with ditto via:
 
 ```csharp
 string taskBody = s.Replace("--insert ", "");
-ditto.Store["tasks"].Insert(new Task(taskBody, false).ToDictionary());
+ditto.Store["tasks"].Upsert(new Task(taskBody, false).ToDictionary());
 ```
 
 5. Check for a switch case for `--toggle`. We will parse out the string without `--toggle` and assume the user's input is a Task document's `_id`. We can then find the document by it's `_id` and call `.update`
@@ -70,7 +70,7 @@ namespace Tasks
                     // highlight-start
                     case string s when command.StartsWith("--insert"):
                         string taskBody = s.Replace("--insert ", "");
-                        ditto.Store["tasks"].Insert(new Task(taskBody, false).ToDictionary());
+                        ditto.Store["tasks"].Upsert(new Task(taskBody, false).ToDictionary());
                         break;
                         // highlight-end
                     // 5.
@@ -174,7 +174,7 @@ namespace Tasks
 
                     case string s when command.StartsWith("--insert"):
                         string taskBody = s.Replace("--insert ", "");
-                        ditto.Store["tasks"].Insert(new Task(taskBody, false).ToDictionary());
+                        ditto.Store["tasks"].Upsert(new Task(taskBody, false).ToDictionary());
                         break;
                     case string s when command.StartsWith("--toggle"):
                         string _idToToggle = s.Replace("--toggle ", "");

--- a/docs/tutorials/tasks/swiftui/3-tasks-list-screen.md
+++ b/docs/tutorials/tasks/swiftui/3-tasks-list-screen.md
@@ -72,7 +72,7 @@ struct TaskRow_Previews: PreviewProvider {
 
 ## 3-2 Create a `TasksListScreenViewModel`
 
-In the world of SwiftUI, the most important design pattern is the MVVM, which stands for Model-View-ViewModel. MVVM strives to separate all data manipulation (Model and ViewModel) and data presentation (UI or View) into distinct areas of concern. When it comes to Ditto, we recommend that you never include references to edit `ditto` in `View.body`. All interactions with `ditto` for `insert`, `update`, `find`, `remove` and `observe` should be within a `ViewModel`. The View should only render data from observable variables from the `ViewModel` and only the `ViewModel` should make direct edits to these variables.
+In the world of SwiftUI, the most important design pattern is the MVVM, which stands for Model-View-ViewModel. MVVM strives to separate all data manipulation (Model and ViewModel) and data presentation (UI or View) into distinct areas of concern. When it comes to Ditto, we recommend that you never include references to edit `ditto` in `View.body`. All interactions with `ditto` for `upsert`, `update`, `find`, `remove` and `observe` should be within a `ViewModel`. The View should only render data from observable variables from the `ViewModel` and only the `ViewModel` should make direct edits to these variables.
 
 Typically we create a `ViewModel` per screen or per page of an application. For the `TasksListScreen` we need some functionality like:
 

--- a/docs/tutorials/tasks/swiftui/4-edit-screen.md
+++ b/docs/tutorials/tasks/swiftui/4-edit-screen.md
@@ -14,7 +14,7 @@ Like before, we need to create an `EditScreenViewModel` for the `EditScreen`. Si
 
 1. The `EditScreenViewModel` needs to be initialized with `ditto` and an optional `task: Task?` value. If the task value is `nil` we need to set the `canDelete` variable to `false`. This means that the user is attempting _create_ a new `Task`. We will use this value to show a delete `Button` in the `EditScreen` later. We will store the `_id: String?` from the `task` parameter and use it later in the `save()` function.
 2. We need two `@Published` variables to bind to a `TextField` and `Toggle` SwiftUI views for the task's `isCompleted` and `body` values. If the `task == nil`, we will set some default values like an empty string and a false `isCompleted` value.
-3. When the user wants to click a save `Button`, we need to `save()` and handle either an `.insert` or `.update` function appropriately. If the local `_id` variable is `nil`, we assume the user is attempting to create a `Task` and will call ditto's `.insert` function. Otherwise, we will attempt to `.update` an existing task with a known `_id`.
+3. When the user wants to click a save `Button`, we need to `save()` and handle either an `.upsert` or `.update` function appropriately. If the local `_id` variable is `nil`, we assume the user is attempting to create a `Task` and will call ditto's `.upsert` function. Otherwise, we will attempt to `.update` an existing task with a known `_id`.
 4. Finally if a delete button is clicked, we attempt to find the document and call `.remove`
 
 ```swift title="EditScreenViewModel.swift"
@@ -55,8 +55,8 @@ class EditScreenViewModel: ObservableObject {
                 mutableDoc?["body"].set(self.body)
             })
         } else {
-            // the user is attempting to insert
-            try! ditto.store["tasks"].insert([
+            // the user is attempting to upsert
+            try! ditto.store["tasks"].upsert([
                 "body": body,
                 "isCompleted": isCompleted
             ])


### PR DESCRIPTION
This deprecates `insert` and `insertWithStrategy`. This significantly simplifies the Concepts section. 

I noticed that rust doesn't yet have `upsert` so I didn't change it here. I think it might be confusing for users if rust also doesn't have an `upsert`, but I err on keeping the documentation at least correct for the currently released version. Do we have an issue yet to update the rust api to include an `upsert` function? 