### PR TITLE
Fix the Rust examples

### DIFF
--- a/docs/installation/rust.md
+++ b/docs/installation/rust.md
@@ -5,15 +5,11 @@ pagination_prev: intro
 pagination_next: concepts/overview
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+import { InstallCode } from "../../src/components/Changelog.tsx";
 
 Create a new project with `cargo init --bin` and add the following to your `Cargo.toml` file.
 
-```toml
-[dependencies.dittolive-ditto]
-version = "1.0"
-```
+<InstallCode framework="rustsdk" />
 
 ```console
 cargo build

--- a/docs/installation/rust.md
+++ b/docs/installation/rust.md
@@ -37,7 +37,10 @@ The rust compiler is natively capable of cross-compiling for a wide range of tar
 ### I get an error: "error: could not find native static library `dittoffi`, perhaps an -L flag is missing". What should I do?
 
 #### Diagnosis
-The Ditto SDK build.rs script failed to download an appropriate ditto binary for your target platform. Check your internet connection is live and Ditto version number is correct. Inspect the downloaded library in the cargo build cache (default is `target/<profile>/build/dittolive-ditto-sys-<hash>/out/libdittoffi.{a,dylib,so,dll}`) using your platforms utilties such as `file`, `otool`, `readelf` or similar. Try updating to the latest release of `dittolive-ditto`. You can also manually download the binary yourself.
+The Ditto SDK build.rs script failed to download an appropriate ditto binary for your target platform.  Look at the build script's log at `target/<profile>/build/dittolive-ditto-sys-<hash>/stderr` for any errors.
+
+Check your internet connection is live and Ditto version number is correct. Inspect the downloaded library in the cargo build cache (default is `target/<profile>/build/dittolive-ditto-sys-<hash>/out/libdittoffi.{a,dylib,so,dll}`) using your platforms utilties such as `file`, `otool`, `readelf` or similar. Try updating to the latest release of `dittolive-ditto`. You can also manually download the binary yourself.
+
 
 #### Solutions
 

--- a/docs/security/online-playground.mdx
+++ b/docs/security/online-playground.mdx
@@ -139,9 +139,9 @@ use dittolive_ditto::prelude::*;
 use std::sync::Arc;
 use std::time::Duration;
 
-let mut ditto = Ditto::builder()
+let ditto = Ditto::builder()
     // creates a `ditto_data` folder in the directory containing the executing process
-    .with_root(Arc::new(PersistentRoot::current_exe()?))
+    .with_root(Arc::new(PersistentRoot::from_current_exe()?))
     .with_identity(|ditto_root| {
       // Provided as an env var, may also be provided as hardcoded string
       let app_id = AppId::from_env("DITTO_APP_ID")?;
@@ -149,10 +149,12 @@ let mut ditto = Ditto::builder()
       let custom_auth_url = None;
       // return the Result<Identity, _> at the end of this closure
       OnlinePlayground::new(ditto_root, app_id, enable_cloud_sync, custom_auth_url)
-    })
+    })?
     .with_transport_config(|_identity| {
-        let mut config = TransportConfig::enable_all_peer_to_peer()
-    })
+        let mut config = TransportConfig::new();
+        config.enable_all_peer_to_peer();
+        config
+    })?
     .build()?;
 
 ditto.set_license_from_env("DITTO_LICENSE")?; // May also be provided as a string

--- a/src/components/Changelog.tsx
+++ b/src/components/Changelog.tsx
@@ -328,7 +328,7 @@ export function InstallCode({
     case "cpp":
       installCode = `curl -O https://software.ditto.live/cpp-${variant}/Ditto/${latest.version}/dist/Ditto.tar.gz && tar xvfz Ditto.tar.gz`;
       break;
-    case "rustsk":
+    case "rustsdk":
       installCode = dedent`
       [dependencies.dittolive-ditto]
       version = "${latest.version}"


### PR DESCRIPTION
I came across a few things to improve while getting started with the Rust crate:
* The Rust installation page wasn't using the `InstallCode` element
* The Rust online playground example code was broken.
* The build script's stderr file contains valuable information for diagnosing errors.