### PR TITLE
Promotes the use of OnlinePlayground identities in the Ditto docs.

### DIFF
--- a/docs/advanced/identities.md
+++ b/docs/advanced/identities.md
@@ -46,9 +46,9 @@ Depending on the Identity used, the Ditto instance may then request the Ditto Cl
 
 * `OnlineWithAuthentication` - Use this identity for most production Apps. The `OnlineWithAuthentication` identity supports both Cloud and peer-to-peer sync with secure authentication, encryption, and access control. Use typically requires configuring an Authentication Provider for your App within the Ditto Cloud portal, which can validate user-provided credentials. This identity also requires a developer-provided implementation of the `DittoAuthEventHandler` (`DittoAuthCallback`) interface.
 * `OnlinePlayground` - A simplified version of the `OnlineWithAuthentication` Identity for prototyping and development use. All modes of sync are supported but no Authentication Provider needs to be configured. Instead, all users will receive full read and write permissions to all App collections and timeseries. Do not use this Identity in production. No `DittoAuthEventHandler` needs to be provided.
-* `SharedKey` - A secure Identity used for "private" Apps where the developer trusts all users, the Ditto-based App, and devices and would prefer a fully self-contained deployment. Ditto instances are each provided with a pre-shared key that is used for mutual authentication. This Identity does NOT support Cloud sync. Typically used with some external device management solution which can provide and rotate the pre-shared key.
-* `Manual` - An advanced Identity where the App developer will provide each Ditto instance with an x509 Client Certificate signed by a common, trusted Certificate Authority. Like `SharedKey` typically deployed along side existing PKI and device management solutions. This Identity cannot sync with `cloud.ditto.live` but may sync with a custom deployment of a Big Peer.
-* `OfflinePlayground` - An *unsecured* identity suitable for local testing, CI/CD pipelines, and peer-to-peer sync. Cloud sync is not permitted. All peers are automatically trusted and no authentication takes place. Do *not* use this Identity in production.
+* `SharedKey` - A secure Identity used for "private" Apps where the developer trusts all users, the Ditto-based App, and devices and would prefer a fully self-contained deployment. Ditto instances are each provided with a pre-shared key that is used for mutual authentication. This Identity does NOT support Cloud sync. Typically used with some external device management solution which can provide and rotate the pre-shared key. Given that this identity doesn't use the Ditto cloud, Ditto instances using this identity must be activated with an offline only license token that can be requested from the app settings page on the [portal](https://portal.ditto.live).
+* `Manual` - An advanced Identity where the App developer will provide each Ditto instance with an x509 Client Certificate signed by a common, trusted Certificate Authority. Like `SharedKey` typically deployed along side existing PKI and device management solutions. This Identity cannot sync with `cloud.ditto.live` but may sync with a custom deployment of a Big Peer. Given that this identity doesn't use the Ditto cloud, Ditto instances using this identity must be activated with an offline only license token that can be requested from the app settings page on the [portal](https://portal.ditto.live).
+* `OfflinePlayground` - An *unsecured* identity suitable for local testing, CI/CD pipelines, and peer-to-peer sync. Cloud sync is not permitted. All peers are automatically trusted and no authentication takes place. Do *not* use this Identity in production. Given that this identity doesn't use the Ditto cloud, Ditto instances using this identity must be activated with an offline only license token that can be requested from the app settings page on the [portal](https://portal.ditto.live).
 
 
 ## Configuring an OnlineWithAuthentication Ditto Identity
@@ -92,7 +92,6 @@ import { init, Ditto } from "@dittolive/ditto"
     authHandler
   }
   const ditto = new Ditto(identity, '/persistence/file/path')
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 })()
 ```
@@ -117,7 +116,6 @@ let identity = DittoIdentity.onlineWithAuthentication(
     authenticationDelegate: AuthDelegate()
 )
 let ditto = Ditto(identity: identity)
-try! ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
 try! ditto.tryStartSync()
 ```
 
@@ -144,7 +142,6 @@ DITIdentity *identity = [[DITIdentity alloc] initOnlineWithAuthenticationWithApp
                                                             authenticationDelegate:[[AuthDelegate alloc] init];
 DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 NSError *error = nil;
-[ditto setLicenseToken: @"REPLACE_ME_WITH_YOUR_LICENSE_TOKEN" error:&error];
 [ditto tryStartSync:&error];
 ```
 
@@ -175,7 +172,6 @@ try {
       AuthCallback()
   )
   val ditto = Ditto(androidDependencies, identity)
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 } catch(e: DittoError) {
   Log.e("Ditto error", e.message!!)
@@ -210,7 +206,6 @@ DittoIdentity identity = new DittoIdentity.OnlineWithAuthentication(
 Ditto ditto = new Ditto(androidDependencies);
 
 try {
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.tryStartSync();
 } catch(DittoError e) {
   Log.e("Ditto Error", e.getMessage())
@@ -242,7 +237,6 @@ var identity = DittoIdentity.OnlineWithAuthentication(
 try
 {
     var ditto = new Ditto(identity);
-    ditto.SetLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
     ditto.TryStartSync();
 }
 catch (DittoException ex)
@@ -275,7 +269,6 @@ Identity identity = Identity::OnlineWithAuthentication(
 );
 try {
   Ditto ditto = Ditto(identity, "/your-persistence-path");
-  ditto.set_license_token("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.try_start_sync();
 } catch (const DittoError &err) {
   std::cout << err.what() << std::endl;
@@ -347,7 +340,6 @@ let mut ditto = Ditto::builder()
     })
     .build()?;
 
-ditto.set_license_from_env("DITTO_LICENSE")?; // May also be provided as a string
 ditto.try_start_sync()?;
 ```
 
@@ -380,7 +372,6 @@ import { init, Ditto } from "@dittolive/ditto"
   await init() // you need to call this at least once before using any of the Ditto API
   const identity = { type: 'onlinePlayground', appID: 'REPLACE_ME_WITH_YOUR_APP_ID' }
   const ditto = new Ditto(identity, '/persistence/file/path')
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 })()
 ```
@@ -390,7 +381,6 @@ import { init, Ditto } from "@dittolive/ditto"
 
 ```swift
 let ditto = Ditto(identity: DittoIdentity.onlinePlayground(appID: "REPLACE_ME_WITH_YOUR_APP_ID"))
-try! ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
 try! ditto.tryStartSync()
 ```
 
@@ -402,7 +392,6 @@ try! ditto.tryStartSync()
 DITIdentity *identity = [[DITIdentity alloc] initOnlinePlaygroundWithAppID:@"REPLACE_ME_WITH_YOUR_APP_ID"];
 DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 NSError *error = nil;
-[ditto setLicenseToken: @"REPLACE_ME_WITH_YOUR_LICENSE_TOKEN" error:&error];
 [ditto tryStartSync:&error];
 ```
 
@@ -414,7 +403,6 @@ try {
   val androidDependencies = AndroidDittoDependencies(context)
   val identity = DittoIdentity.OnlinePlayground(androidDependencies, appID = "REPLACE_ME_WITH_YOUR_APP_ID")
   val ditto = Ditto(androidDependencies, identity)
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 } catch(e: DittoError) {
   Log.e("Ditto error", e.message!!)
@@ -431,7 +419,6 @@ DittoIdentity identity = new DittoIdentity.OnlinePlayground(androidDependencies,
 Ditto ditto = new Ditto(androidDependencies, identity);
 
 try {
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.tryStartSync();
 } catch(DittoError e) {
   Log.e("Ditto Error", e.getMessage())
@@ -446,7 +433,6 @@ try
 {
     var identity = DittoIdentity.OnlinePlayground("REPLACE_ME_WITH_YOUR_APP_ID");
     var ditto = new Ditto(identity);
-    ditto.SetLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
     ditto.TryStartSync();
 }
 catch (DittoException ex)
@@ -462,7 +448,6 @@ catch (DittoException ex)
 auto identity = Identity::OnlinePlayground("REPLACE_ME_WITH_YOUR_APP_ID");
 try {
   Ditto ditto = Ditto(identity, "/your-persistence-path");
-  ditto.set_license_token(invalid_license);
   ditto.try_start_sync();
 } catch (const DittoError &err) {
   std::cout << err.what() << std::endl;
@@ -493,7 +478,6 @@ let mut ditto = Ditto::builder()
     })
     .build()?;
 
-ditto.set_license_from_env("DITTO_LICENSE")?; // May also be provided as a string
 ditto.try_start_sync()?;
 ```
 

--- a/docs/advanced/monitoring-network-transports.md
+++ b/docs/advanced/monitoring-network-transports.md
@@ -34,9 +34,8 @@ ditto.tryStartSync()
 
 ```swift
 // Setting up inside a ViewController
-ditto = Ditto()
+let ditto = Ditto(identity: DittoIdentity.onlinePlayground(appID: "REPLACE_ME_WITH_YOUR_APP_ID"))
 ditto.delegate = self
-ditto.setLicenseToken("...")
 try! ditto.tryStartSync()
 ```
 
@@ -45,9 +44,9 @@ try! ditto.tryStartSync()
 
 ```objc
 // Setting up inside a ViewController
-DITDitto *ditto = [[DITDitto alloc] init];
+DITIdentity *identity = [[DITIdentity alloc] initOnlinePlaygroundWithAppID:@"REPLACE_WITH_APP_ID"];
+DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 ditto.delegate = self;
-[ditto setLicenseToken: @"..."];
 [ditto tryStartSync:nil];
 ```
 
@@ -57,9 +56,8 @@ ditto.delegate = self;
 ```kotlin
 // Setting up inside an Activity
 val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
-val ditto = Ditto(androidDependencies)
+val ditto = Ditto(androidDependencies, DittoIdentity.OnlinePlayground(androidDependencies, "REPLACE_WITH_APP_ID"))
 ditto.callback = this
-ditto.setLicenseToken("...")
 ditto.tryStartSync()
 ```
 
@@ -69,9 +67,8 @@ ditto.tryStartSync()
 ```java
 // Setting up inside an Activity
 DefaultAndroidDittoDependencies androidDependencies = new DefaultAndroidDittoDependencies(getApplicationContext());
-Ditto ditto = new Ditto(androidDependencies);
+Ditto ditto = new Ditto(androidDependencies, new DittoIdentity.OnlinePlayground(androidDependenciesOne, "REPLACE_WITH_APP_ID"));
 ditto.callback = this;
-ditto.setLicenseToken("...");
 ditto.tryStartSync();
 ```
 
@@ -80,8 +77,8 @@ ditto.tryStartSync();
 
 ```csharp
 // Setting up inside Main
-Ditto ditto = new Ditto();
-ditto.setLicenseToken("...");
+DittoIdentity identity = DittoIdentity.OnlinePlayground("REPLACE_WITH_APP_ID");
+Ditto onlineDitto = new Ditto(identity);
 ditto.tryStartSync();
 ```
 

--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -46,8 +46,9 @@ buildscript {
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 ```
+5. Access the [portal](https://portal.ditto.live) to create a new app. Apps created on the portal will automatically sync data between them and also to the Ditto cloud. Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
 
-5. Register your license token as below. We recommend placing this in your Application.onCreate method:
+6. Create your Ditto instance as below. We recommend placing this in your Application.onCreate method:
 
 
 <Tabs
@@ -62,8 +63,7 @@ buildscript {
 
 ```kotlin
 val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
-val ditto = Ditto(androidDependencies)
-ditto.setLicenseToken("<ditto_license_token>")
+val ditto = Ditto(androidDependencies, DittoIdentity.OnlinePlayground(androidDependencies, "REPLACE_WITH_APP_ID"))
 ditto.tryStartSync()
 ```
 
@@ -72,8 +72,7 @@ ditto.tryStartSync()
 
 ```java
 DefaultAndroidDittoDependencies androidDependencies = new DefaultAndroidDittoDependencies(applicationContext);
-Ditto ditto = new Ditto(androidDependencies);
-ditto.setLicenseToken("<ditto_license_token>");
+Ditto ditto = new Ditto(androidDependencies, new DittoIdentity.OnlinePlayground(androidDependenciesOne, "REPLACE_WITH_APP_ID"));
 ditto.tryStartSync();
 ```
 

--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -138,7 +138,9 @@ If your app already has an **Info.plist** file, you can right click on it and **
 
 The values like `Uses WiFi to connect and sync with nearby devices` will be displayed in a prompt. Replace it with whatever language is best for your users.
 
-6. You can now use Ditto in your application:
+6. Access the [portal](https://portal.ditto.live) to create a new app. Apps created on the portal will automatically sync data between them and also to the Ditto cloud. Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
+
+7. You can now use Ditto in your application:
 
 <Tabs
   groupId="programming-language"
@@ -153,8 +155,7 @@ The values like `Uses WiFi to connect and sync with nearby devices` will be disp
 ```swift
 import DittoSwift
 
-let ditto = Ditto()
-try! ditto.setLicenseToken("my license token")
+let ditto = Ditto(identity: .onlinePlayground(appID: "REPLACE_WITH_APP_ID"))
 try! ditto.tryStartSync()
 ```
 
@@ -164,13 +165,9 @@ try! ditto.tryStartSync()
 ```objc
 #import <DittoObjC/DittoObjC.h>
 
-
-DITDitto *ditto = [[DITDitto alloc] init];
+DITIdentity *identity = [[DITIdentity alloc] initOnlinePlaygroundWithAppID:@"REPLACE_WITH_APP_ID"];
+DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 NSError *error = nil;
-
-if (![ditto setLicenseToken:@"my license token": error:&error]) {
-  NSLog(@"Error setting license token: %@", error);
-}
 
 if (![ditto tryStartSync:&error]) {
   NSLog(@"Error starting sync: %@", error);

--- a/docs/security/online-playground.mdx
+++ b/docs/security/online-playground.mdx
@@ -44,7 +44,6 @@ import { init, Ditto } from "@dittolive/ditto"
   await init() // you need to call this at least once before using any of the Ditto API
   const identity = { type: 'onlinePlayground', appID: 'REPLACE_ME_WITH_YOUR_APP_ID' }
   const ditto = new Ditto(identity, '/persistence/file/path')
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 })()
 ```
@@ -54,7 +53,6 @@ import { init, Ditto } from "@dittolive/ditto"
 
 ```swift
 let ditto = Ditto(identity: DittoIdentity.onlinePlayground(appID: "REPLACE_ME_WITH_YOUR_APP_ID"))
-try! ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
 try! ditto.tryStartSync()
 ```
 
@@ -65,7 +63,6 @@ try! ditto.tryStartSync()
 DITIdentity *identity = [[DITIdentity alloc] initOnlinePlaygroundWithAppID:@"REPLACE_ME_WITH_YOUR_APP_ID"];
 DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 NSError *error = nil;
-[ditto setLicenseToken: @"REPLACE_ME_WITH_YOUR_LICENSE_TOKEN" error:&error];
 [ditto tryStartSync:&error];
 ```
 
@@ -77,7 +74,6 @@ try {
   val androidDependencies = AndroidDittoDependencies(context)
   val identity = DittoIdentity.OnlinePlayground(androidDependencies, appID = "REPLACE_ME_WITH_YOUR_APP_ID")
   val ditto = Ditto(androidDependencies, identity)
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 } catch(e: DittoError) {
   Log.e("Ditto error", e.message!!)
@@ -93,7 +89,6 @@ DittoIdentity identity = new DittoIdentity.OnlinePlayground(androidDependencies,
 Ditto ditto = new Ditto(androidDependencies, identity);
 
 try {
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.tryStartSync();
 } catch(DittoError e) {
   Log.e("Ditto Error", e.getMessage())
@@ -107,7 +102,6 @@ try {
 try
 {
     var ditto = new Ditto(DittoIdentity.OnlinePlayground("REPLACE_ME_WITH_YOUR_APP_ID"));
-    ditto.SetLicenseToken(tamperedLicense);
     ditto.TryStartSync();
 }
 catch (DittoException ex)
@@ -123,7 +117,6 @@ catch (DittoException ex)
 auto identity = Identity::OnlinePlayground("REPLACE_ME_WITH_YOUR_APP_ID");
 try {
   Ditto ditto = Ditto(identity, "/your-persistence-path");
-  ditto.set_license_token(invalid_license);
   ditto.try_start_sync();
 } catch (const DittoError &err) {
   std::cout << err.what() << std::endl;
@@ -155,7 +148,6 @@ let mut ditto = Ditto::builder()
     })
     .build()?;
 
-ditto.set_license_from_env("DITTO_LICENSE")?; // May also be provided as a string
 ditto.try_start_sync()?;
 ```
 

--- a/docs/security/online-with-authentication/setup-client-side.mdx
+++ b/docs/security/online-with-authentication/setup-client-side.mdx
@@ -45,7 +45,6 @@ import { init, Ditto } from "@dittolive/ditto"
   }
 
   const ditto = new Ditto(identity, '/persistence/file/path')
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 })()
 ```
@@ -72,7 +71,6 @@ let identity = DittoIdentity.onlineWithAuthentication(
 )
 
 let ditto = Ditto(identity: identity)
-try! ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
 try! ditto.tryStartSync()
 ```
 
@@ -100,7 +98,6 @@ DITIdentity *identity = [[DITIdentity alloc] initOnlineWithAuthenticationWithApp
                                                             authenticationDelegate:[[AuthDelegate alloc] init];
 DITDitto *ditto = [[DITDitto alloc] initWithIdentity:identity];
 NSError *error = nil;
-[ditto setLicenseToken: @"REPLACE_ME_WITH_YOUR_LICENSE_TOKEN" error:&error];
 [ditto tryStartSync:&error];
 ```
 
@@ -131,7 +128,6 @@ val identity = DittoIdentity.OnlineWithAuthentication(
 )
 val ditto = Ditto(androidDependencies, identity)
 try {
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN")
   ditto.tryStartSync()
 } catch(e: DittoError) {
   Log.e("Ditto error", e.message!!)
@@ -165,7 +161,6 @@ DittoIdentity identity = new DittoIdentity.OnlineWithAuthentication(
 Ditto ditto = new Ditto(androidDependencies);
 
 try {
-  ditto.setLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.tryStartSync();
 } catch(DittoError e) {
   Log.e("Ditto Error", e.getMessage())
@@ -197,7 +192,6 @@ var identity = DittoIdentity.OnlineWithAuthentication(
 try
 {
     var ditto = new Ditto(identity);
-    ditto.SetLicenseToken("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
     ditto.TryStartSync();
 }
 catch (DittoException ex)
@@ -230,7 +224,6 @@ Identity identity = Identity::OnlineWithAuthentication(
 );
 try {
   Ditto ditto = Ditto(identity, "/your-persistence-path");
-  ditto.set_license_token("REPLACE_ME_WITH_YOUR_LICENSE_TOKEN");
   ditto.try_start_sync();
 } catch (const DittoError &err) {
   std::cout << err.what() << std::endl;
@@ -302,7 +295,6 @@ let mut ditto = Ditto::builder()
     })
     .build()?;
 
-ditto.set_license_from_env("DITTO_LICENSE")?; // May also be provided as a string
 ditto.try_start_sync()?;
 ```
 

--- a/docs/tutorials/tasks/android-kotlin/4-integrate-ditto.md
+++ b/docs/tutorials/tasks/android-kotlin/4-integrate-ditto.md
@@ -2,7 +2,13 @@
 title: "4 - Integrate Ditto"
 ---
 
-## 4-1 Integrate Ditto
+## 4-1 Create Your Ditto App on the Portal
+
+In order to integrate Ditto into our app we first need to create a new app on the [portal](https://portal.ditto.live). Apps created on the portal will automatically sync data between them and also to the Ditto cloud.
+
+Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
+
+## 4-2 Integrate Ditto
 
 To finish the app, we now need to integrate Ditto. We will initialize it in the `onCreate()` function within `MainActivity`. Furthermore, we will add handlers for the swipe to delete and listening for row clicks to mark a task as completed (or in-completed). Replace the existing `onCreate()` code with this:
 
@@ -27,12 +33,8 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
     // Create an instance of Ditto
     val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
-    val ditto = Ditto(androidDependencies)
+    val ditto = Ditto(androidDependencies, DittoIdentity.OnlinePlayground(androidDependencies, "REPLACE_WITH_YOUR_APP_ID"))
     this.ditto = ditto
-
-    // Set your Ditto access license
-    // The SDK will not work without this!
-    ditto.setLicenseToken("<INSERT ACCESS LICENSE>")
 
     // This starts Ditto's background synchronization
     ditto.tryStartSync()
@@ -77,7 +79,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
 The important things to note is that you need an access license to use Ditto. If you do not have one yet, reach out and we can supply one. To enable background synchronization, we need to call `tryStartSync()` which allows you to control when synchronization occurs. For this application we want it to run the entire time the app is in use.
 
-## 4-2 Setup Live Query
+## 4-3 Setup Live Query
 
 Finally, we then use Ditto's key API to observe changes to the database by creating a live-query in the `setupTaskList()` function. This allows us to set the initial state of the `RecyclerView` after the query is immediately run and then subsequently get callbacks for any new data changes that occur locally or that were synced from other devices:
 
@@ -113,7 +115,7 @@ fun setupTaskList() {
 
 This is a best-practice when using Ditto, since it allows your UI to simply react to data changes which can come at any time given the ad-hoc nature of how Ditto synchronizes with nearby devices.
 
-## 4-3 Check For Location Permissions
+## 4-4 Check For Location Permissions
 
 Android requires you to request location permissions to fully enable Bluetooth Low Energy (since Bluetooth can be involved with location tracking). Insert this function in `MainActivity`:
 
@@ -131,7 +133,7 @@ fun checkLocationPermission() {
 
 ```
 
-## 4-4 Ensure Imports
+## 4-5 Ensure Imports
 
 Just in case your project did not auto import as you went along, you can replace the import statements in `MainActivity` with these:
 

--- a/docs/tutorials/tasks/jetpack-compose/2-configure-ditto.md
+++ b/docs/tutorials/tasks/jetpack-compose/2-configure-ditto.md
@@ -2,7 +2,13 @@
 title: '2 - Configure Ditto'
 ---
 
-## 2-1 Create Application Class
+## 2-1 Create Your Ditto App
+
+Before we start coding, we first need to create a new app in the [portal](https://portal.ditto.live). Apps created on the portal will automatically sync data between them and also to the Ditto cloud.
+
+Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
+
+## 2-2 Create Application Class
 
 Typically, applications with Ditto will need to run Ditto as a singleton. To construct Ditto it'll need access to a live Android `Context`. Since the Application class is a singleton and has the necessary `Context`, we can create a subclass called __TasksApplication.kt__
 
@@ -28,7 +34,7 @@ class TasksApplication: Application() {
         // construct a DefaultAndroidDittoDependencies object with the applicationContext
         val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
         // for this example we will use a Development identity
-        val identity = DittoIdentity.Development(appName = "live.ditto.tasks", dependencies = androidDependencies);
+        val identity = DittoIdentity.OnlinePlayground(appID = "REPLACE_ME", dependencies = androidDependencies);
         ditto = Ditto(androidDependencies, identity)
     }
 
@@ -41,7 +47,7 @@ Now you will be able to access this Ditto anywhere in your application like so:
 val docs = TasksApplication.ditto!!.store["tasks].findAll().exec()
 ```
 
-## 2-2 Add Permissions and Register Class
+## 2-3 Add Permissions and Register Class
 
 In order for Ditto to sync, we will need to add permissions to the __AndroidManifest.xml__ file. [For more information about these permissions, click here](/advanced/platform-permissions/android-platform-permissions). In addition we will need to register our custom `TasksApplication` as the main Application class in the `<application>` tag.
 
@@ -79,13 +85,11 @@ In order for Ditto to sync, we will need to add permissions to the __AndroidMani
 
 ```
 
-## 2-3 Start Ditto Sync
+## 2-4 Start Ditto Sync
 
 When Android studio created the project, it should have created a file called __MainActivity.kt__. In this file, we will take the singleton `TasksApplication.ditto!!` and begin to start the sync process with `tryStartSync()`
 
-1. Notice the line `ditto!!.setLicenseToken("<REPLACE_ME>")`, please add your Ditto license token. For more information about how to get a license token please go to https://portal.ditto.live, sign up and create an app.
-
-2. The app will show a `Toast` error if `tryStartSync` encounters a mistake. Don't worry if an error occurs or if you omit this step, Ditto will continue to work as a local database. However, it's advised that you fix the errors to see the app sync across multiple devices.
+The app will show a `Toast` error if `tryStartSync` encounters a mistake. Don't worry if an error occurs or if you omit this step, Ditto will continue to work as a local database. However, it's advised that you fix the errors to see the app sync across multiple devices.
 
 ```kotlin title="MainActivity" {5-18}
 class MainActivity : ComponentActivity() {
@@ -94,8 +98,6 @@ class MainActivity : ComponentActivity() {
 
       val ditto = TasksApplication.ditto
       try {
-          // 1.
-          ditto!!.setLicenseToken("<REPLACE_ME>")
           ditto!!.tryStartSync()
       } catch (e: DittoError) {
           // 2.
@@ -117,7 +119,7 @@ class MainActivity : ComponentActivity() {
 ```
 
 
-## 2-4 Create a Task data class
+## 2-5 Create a Task data class
 
 Ditto is a document database, which represents all of its rows in the database a JSON-like structure. In this tutorial, we will define each task like so:
 

--- a/docs/tutorials/tasks/jetpack-compose/3-navigation.md
+++ b/docs/tutorials/tasks/jetpack-compose/3-navigation.md
@@ -54,7 +54,6 @@ class MainActivity : ComponentActivity() {
 
         val ditto = TasksApplication.ditto
         try {
-            ditto!!.setLicenseToken("<REPLACE_ME>")
             ditto!!.tryStartSync()
         } catch (e: DittoError) {
             Toast.makeText(

--- a/docs/tutorials/tasks/swiftui/2-configure-ditto.md
+++ b/docs/tutorials/tasks/swiftui/2-configure-ditto.md
@@ -2,7 +2,13 @@
 title: '2 - Configure Ditto'
 ---
 
-## 2-1 Add Permissions to the `Info.plist`
+## 2-1 Create Your Ditto App
+
+Before we start coding, we first need to create a new app in the [portal](https://portal.ditto.live). Apps created on the portal will automatically sync data between them and also to the Ditto cloud.
+
+Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
+
+## 2-2 Add Permissions to the `Info.plist`
 
 For Ditto to fully use all the network transports like Bluetooth Low Energy, Local Area Network, Apple Wireless Direct, the app will need to ask the user for permissions. These permission prompts need to be in the __Info.plist__ file of your project.
 
@@ -28,12 +34,12 @@ For Ditto to fully use all the network transports like Bluetooth Low Energy, Loc
 
 For more information on these permissions [click here](/advanced/platform-permissions/ios-platform-permissions)
 
-## 2-2 Add `ditto` to `TasksApp.swift`
+## 2-3 Add `ditto` to `TasksApp.swift`
 
 When Xcode generated your project, there should be a file called __TasksApp.swift__. We will need an instance of Ditto throughout this tutorial and the app's lifecycle.
 
 1. First import Ditto with `import DittoSwift`
-2. Construct an instance of Ditto with a development identity with an app name `"live.ditto.tasks"`. This value is important if you are interested in sync with another device with the TasksApp. We are using a `.development` setup, which should suffice for this tutorial. However, you should never deploy this to a production environment like the Apple App Store.
+2. Construct an instance of Ditto with an online playground identity using the APP ID of the app that you just created on the portal. We are using an `.onlinePlayground` setup, which should suffice for this tutorial. However, you should never deploy this to a production environment like the Apple App Store.
 3. We will call `tryStartSync` as soon as the app's `ContentView` appears. This method can throw an error in the event that the license token is invalid or expired. Add two `@State` variables to capture if `ditto.tryStartSync` throws an error. One variable will be `@State var isPresentingAlert = false` and the other is a `@State var errorMessage = ""`.
 4. Add an `.onAppear` function and give it a license token. Look for `"<REPLACE_ME>"` and insert your valid license token. You can get a license token from our [cloud portal](https://portal.ditto.live). If the `tryStartSync()` fails, we will set `isPresentingAlert = true` and set the `errorMessage` to the error's `.localizedDescription`.
 5. We will then present a `.alert` if `isPresentingAlert` is true. Notice that we will pass a `@State` variable as a binding type, which is why we denoted `$isPresentingAlert` prefixed with a `$`. To learn more about SwiftUI's `Binding` types like `@State` [click here.](https://developer.apple.com/documentation/swiftui/state-and-data-flow)
@@ -49,7 +55,7 @@ struct TasksApp: App {
 
     // 2.
     // highlight-next-line
-    var ditto = Ditto(identity: .offlinePlayground(appID: "live.ditto.tasks"))
+    var ditto = Ditto(identity: .onlinePlayground(appID: "<REPLACE_ME>"))
 
     // 3.
     // highlight-start
@@ -65,7 +71,6 @@ struct TasksApp: App {
                 // highlight-start
                 .onAppear(perform: {
                     do {
-                        try ditto.setLicenseToken("<REPLACE_ME>")
                         try ditto.tryStartSync()
                     } catch (let err){
                         isPresentingAlert = true
@@ -85,7 +90,7 @@ struct TasksApp: App {
 ```
 
 
-## 2-3 Create a `Task` struct
+## 2-4 Create a `Task` struct
 
 Ditto is a document database, which represents all of its rows in the database a JSON-like structure. In this tutorial, we will define each task like so:
 
@@ -152,7 +157,7 @@ let tasks: [Task] = ditto.store["tasks"].findAll().exec().map({ Task(document: $
 
 Once we set up our user interface, you'll notice that reading these values becomes a bit easier with this added structure.
 
-## 2-4 Create a `TasksListScreen` view
+## 2-5 Create a `TasksListScreen` view
 
 When we generated the project, Xcode created a default `ContentView`, which need to swap out for a better starter view. Let's create a view called `TasksListScreen` which will show the list of the views.
 

--- a/docs/tutorials/tasks/uikit/3-tasks-list-screen.md
+++ b/docs/tutorials/tasks/uikit/3-tasks-list-screen.md
@@ -4,7 +4,15 @@ title: "3 - Showing the List of Tasks"
 
 Almost done! We have our UI in place and Ditto installed, so let's add the logic to create and display tasks by using Ditto's APIs.
 
-## 3-1 Setup TasksTableViewController
+
+## 3-1 Create Your Ditto App on the Portal
+
+Before we start coding, we first need to create a new app in the [portal](https://portal.ditto.live). Apps created on the portal will automatically sync data between them and also to the Ditto cloud.
+
+Each app created on the portal has a unique `appID` which can be seen on your app's settings page once the app has been created. This ID is used in subsequent sections to configure your Ditto instance.
+
+
+## 3-2 Setup TasksTableViewController
 
 First, we need to add some variables that will be created on `viewDidLoad` of the `TasksTableViewController` so adjust the class to match this code:
 
@@ -24,13 +32,9 @@ class TaskTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         // Create an instance of Ditto
-        ditto = Ditto()
-
-        // Set your Ditto access license
-        // The SDK will not work without this!
-        ditto.setLicenseToken("<INSERT ACCESS LICENSE>")
+        ditto = Ditto(identity: .onlinePlayground(appID: "REPLACE_ME"))
 
         // This starts Ditto's background synchronization
         ditto.tryStartSync()
@@ -95,7 +99,7 @@ class TaskTableViewController: UITableViewController {
 }
 ```
 
-Let's breakdown what this code does. First, we create the variables needed and then initialize them in `viewDidLoad()` . The important things to note is that you need an access license to use Ditto. If you do not have one yet, reach out and we can supply one. To enable background synchronization, we need to call `tryStartSync()` which allows you to control when synchronization occurs. For this application we want it to run the entire time the app is in use.
+Let's breakdown what this code does. First, we create the variables needed and then initialize them in `viewDidLoad()` . To enable background synchronization, we need to call `tryStartSync()` which allows you to control when synchronization occurs. For this application we want it to run the entire time the app is in use.
 
 ```swift
 // These hold references to Ditto for easy access
@@ -111,11 +115,7 @@ override func viewDidLoad() {
     super.viewDidLoad()
 
     // Create an instance of Ditto
-    ditto = Ditto()
-
-    // Set your Ditto access license
-    // The SDK will not work without this!
-    ditto.setLicenseToken("<INSERT ACCESS LICENSE>")
+    ditto = Ditto(identity: .onlinePlayground(appID: "REPLACE_ME"))
 
     // This starts Ditto's background synchronization
     ditto.tryStartSync()
@@ -182,7 +182,7 @@ func setupTaskList() {
 
 This is a best-practice when using Ditto, since it allows your UI to simply react to data changes which can come at any time given the ad-hoc nature of how Ditto synchronizes with nearby devices. With this in place, we can now add user actions and configure the `UITableview` to display the tasks.
 
-## 3-2 Add A Task
+## 3-3 Add A Task
 
 To allow the user to create a task we want to display an alert view in response to clicking the add bar item. Add the following code to the `didClickAddTask()` function we added earlier:
 code-tabs
@@ -228,7 +228,7 @@ _ = try! self.collection.insert([
 ])
 ```
 
-## 3-3 Configure UITableView To Display Task List
+## 3-4 Configure UITableView To Display Task List
 
 To ensure the UITableView can display the tasks, we need to configure it. Adjust
 your `TasksTableViewController` to include the following code (these functions


### PR DESCRIPTION
With the upcoming release of https://github.com/getditto/ditto/issues/4976 the docs have been updated to promote the use of OnlinePlayground identities, instead of the prior default OfflinePlayground identities, that were requiring a call to `setLicenseToken`  as part of most configurations steps.

Using the online playground mode in the code examples has caused the call to `setLicenseToken` to be removed from all of them.

This should only be released to the documentation website once the new SDK version with the  API is release.