### PR TITLE
Add `startSync` to JS installation instructions

### DIFF
--- a/docs/installation/javascript.mdx
+++ b/docs/installation/javascript.mdx
@@ -31,6 +31,7 @@ import { init, Ditto } from '@dittolive/ditto'
   await init() // you need to call this at least once before using any of the Ditto API
   const identity = { type: 'onlinePlayground', appID: 'com.example.ditto' }
   const ditto = new Ditto(identity, 'playground')
+  ditto.startSync()
 })()
 ```
 


### PR DESCRIPTION
Keeping things in sync with the portal's quickstart instructions. See PR: https://github.com/getditto/cloud-services/pull/1228

We use `startSync` instead of `tryStartSync` because in JS they're just aliases.