### PR TITLE
grammar fix

### DIFF
--- a/docs/android/tutorial/jetpack-compose/2-configure-ditto.md
+++ b/docs/android/tutorial/jetpack-compose/2-configure-ditto.md
@@ -123,7 +123,7 @@ These Task documents will all be in the "tasks" collection. We will be referenci
 val tasksCollection = TasksApplication.ditto!!.store["tasks"]
 ```
 
-Ditto documents have a flexible structure. Oftentimes, in strongly-typed languages like Kotlin, we will create a data structure give more definition to the app.
+Ditto documents have a flexible structure. Oftentimes, in strongly-typed languages like Kotlin, we will create a data structure to give more definition to the app.
 
 Create a new Kotlin file called __Task.kt__ in your project.
 


### PR DESCRIPTION
simple grammar fix. But, is there a reason why we have force unwraps `!!` everywhere in the sample app and tutorial documentation? It's a better practice to use null safety, which is a major advantage of Kotlin over Java.