### PR TITLE
Link to the latest API reference docs for each SDK in the sidebar.

### DIFF
--- a/docs/android/sidebar.js
+++ b/docs/android/sidebar.js
@@ -16,6 +16,6 @@ module.exports = common({
     api: {
         type: "link",
         label: "API Reference",
-        href: downloadedChangelog.android.Ditto["3.0.1"].api_reference_docs_url,
+        href: downloadedChangelog.android.Ditto.latest.api_reference_docs_url,
     }
 })

--- a/docs/cpp/sidebar.js
+++ b/docs/cpp/sidebar.js
@@ -15,8 +15,8 @@ const common = require('../common/sidebar.js')
 module.exports = common({
   api: {
     type: "link",
-    label: "API Reference", 
-    href: downloadedChangelog.cpp.Ditto["3.0.1"].api_reference_docs_url,
+    label: "API Reference",
+    href: downloadedChangelog.cpp.Ditto.latest.api_reference_docs_url,
   }
 })
 

--- a/docs/csharp/sidebar.js
+++ b/docs/csharp/sidebar.js
@@ -4,7 +4,7 @@ const common = require('../common/sidebar.js')
 module.exports = common({
   api: {
     type: "link",
-    label: "API Reference", 
-    href: downloadedChangelog.dotnet.Ditto["3.0.1"].api_reference_docs_url,
+    label: "API Reference",
+    href: downloadedChangelog.dotnet.Ditto.latest.api_reference_docs_url,
   }
 })

--- a/docs/ios/sidebar.js
+++ b/docs/ios/sidebar.js
@@ -18,13 +18,13 @@ module.exports = common({
     label: "API Reference",
     items: [{
       type: "link",
-      label: "Swift", 
-      href: downloadedChangelog.cocoa.DittoSwift["3.0.1"].api_reference_docs_url,
+      label: "Swift",
+      href: downloadedChangelog.cocoa.DittoSwift.latest.api_reference_docs_url,
     },
     {
       type: "link",
-      label: "ObjC", 
-      href: downloadedChangelog.cocoa.DittoObjC["3.0.1"].api_reference_docs_url,
+      label: "ObjC",
+      href: downloadedChangelog.cocoa.DittoObjC.latest.api_reference_docs_url,
     }]
   },
 })

--- a/docs/javascript/sidebar.js
+++ b/docs/javascript/sidebar.js
@@ -15,7 +15,7 @@ const common = require('../common/sidebar.js')
 module.exports = common({
   api: {
     type: "link",
-    label: "API Reference", 
-    href: downloadedChangelog.js.Ditto["3.0.1"].api_reference_docs_url,
+    label: "API Reference",
+    href: downloadedChangelog.js.Ditto.latest.api_reference_docs_url,
   }
 })

--- a/docs/raspberrypi/sidebar.js
+++ b/docs/raspberrypi/sidebar.js
@@ -4,7 +4,7 @@ const common = require('../common/sidebar.js')
 module.exports = common({
   api: {
     type: "link",
-    label: "API Reference", 
-    href: downloadedChangelog.cpp.Ditto["3.0.1"].api_reference_docs_url,
+    label: "API Reference",
+    href: downloadedChangelog.cpp.Ditto.latest.api_reference_docs_url,
   }
 })

--- a/docs/rust/sidebar.js
+++ b/docs/rust/sidebar.js
@@ -15,7 +15,7 @@ const common = require('../common/sidebar.js')
 module.exports = common({
   api: {
     type: "link",
-    label: "API Reference", 
-    href: downloadedChangelog.rustsdk.Ditto["3.0.1"].api_reference_docs_url,
+    label: "API Reference",
+    href: downloadedChangelog.rustsdk.Ditto.latest.api_reference_docs_url,
   }
 })


### PR DESCRIPTION
We previously had an issue where _any_ release would become listed as the latest release for an SDK if it had a version number greater than anything previous, even if it was a pre-release (alpha, beta, etc).

This has since been fixed and I've manually updated the `releases.json` file to have correct entries for the latest release for each SDK.

This means we can now revert to using the `latest` entry in `releases.json` for each SDK to populate the API reference docs link in the sidebar rather than harcoding 3.0.1, which is no longer the latest (we're up to 3.0.6).