### PR TITLE
Fix "inspections" typo

### DIFF
--- a/docs/common/datamodel/map.mdx
+++ b/docs/common/datamodel/map.mdx
@@ -73,7 +73,7 @@ When both devices synchronize, both updates will merge. You will see the mileage
 
 What would be the best approach when two devices make changes to the same field on the same document while both are offline, and then connect again. If you use a Register, the CRDT gives priority to the “latest” change, because Registers are always Last Writer Wins. But if you would like to audit these conflicts, you can use a Map.
 
-For example, say we want to render the inspections performed on a car in a list view. We provide a field insepctions and give each writer an ID as the field. For example, say you have two peers: peer 1 has a unique ID of `ghj789` and peer 2 has an ID `def456`.
+For example, say we want to render the inspections performed on a car in a list view. We provide a field inspections and give each writer an ID as the field. For example, say you have two peers: peer 1 has a unique ID of `ghj789` and peer 2 has an ID `def456`.
 
 You can model that list of operations as a map object inside of your document. The UI can then choose how to render these changes based on whatever information each peer has provided in the map.
 


### PR DESCRIPTION
Thank you for your contribution to the Ditto documentation repository. 

--- 

### Description

Fix "inspections" typo.

### Checklist

- [ ] My code builds clean without any errors or warnings
- [ ] I have viewed your page in the netlify preview link (below) and confirmed that there are no broken links
- [ ] I have run my changes through a spell checker
- [ ] If I changed a link location, I added an entry to the `build/_redirects` file according to the [Netlify specification](https://docs.netlify.com/routing/redirects/redirect-options/)
- [ ] I have linked this PR to any existing issue by mentioning the issue in the description body
- [ ] I will close any relevant GitHub issues once my PR is merged
